### PR TITLE
fix:[#47] Remove `no_offers` message form delete services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Bundle status changes to draft if any of its offers changes the status from public to other (@maria-j-k)
 - Fix access_type validator in offer (@maria-j-k)
 - Compare/Favourite icons on the service page (@jarekzet)
+- Removed `no_offers` message in deleted services (@goreck888)
 
 
 ## [3.57.0]

--- a/app/views/backoffice/services/_service.html.haml
+++ b/app/views/backoffice/services/_service.html.haml
@@ -5,4 +5,4 @@
   = link_to backoffice_service_path(service) do
     = highlighted_for(:name, service, highlights[service.id])
   %br
-  = offers_status(service)
+  = offers_status(service) unless service.deleted?

--- a/app/views/backoffice/services/show.html.haml
+++ b/app/views/backoffice/services/show.html.haml
@@ -2,7 +2,7 @@
 - breadcrumb :backoffice_service, @service
 
 .container.p-0.backoffice
-  - if @service.offers.blank?
+  - if @service.offers.blank? && !@service.deleted?
     .alert.alert-danger.mb-0.text-center
       = _("This service has no offers. Add one offer to make possible for a user to Access the service.")
   - elsif @service.published? && @service.offers.published.blank?

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -522,6 +522,20 @@ RSpec.feature "Services in backoffice", manager_frontend: true do
       expect(service.offers).to eq([offer])
     end
 
+    scenario "I don't see warning about published offers in the deleted service", js: true do
+      service = create(:service, status: :deleted)
+
+      visit backoffice_service_path(service)
+
+      expect(page).to_not have_content(
+        "This service has no offers. " \
+          "Add one offer to make possible for a user to Access the service."
+      )
+      offer = create(:offer, service: service)
+      service.reload
+      expect(service.offers).to eq([offer])
+    end
+
     scenario "Offer are converted from markdown to html on service view", skip: "New Offer Wizard" do
       offer = create(:offer, name: "offer1", description: "# Test offer\r\n\rDescription offer")
       create(:offer, service: offer.service)


### PR DESCRIPTION
Remove a message about lack of published offers
in services with status `:deleted`

Closes #47