### PR TITLE
fix:[#HOTFIX] Propagation of service relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Back to previous button fixed (@maria-j-k)
 - Removed `no_offers` message in deleted services (@goreck888)
 - Redirect to login when unlogged user is ordering a service(@goreck888)
+- Propagation of service relationships (@goreck888)
 
 
 ## [3.57.0]

--- a/app/models/service_relationship.rb
+++ b/app/models/service_relationship.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 class ServiceRelationship < ApplicationRecord
+  before_create :set_type
+
   belongs_to :source, class_name: "Service", foreign_key: "source_id"
   belongs_to :target,
              class_name: "Service",
              foreign_key: "target_id",
              foreign_type: :type,
-             optional: true,
-             polymorphic: true
+             polymorphic: true,
+             optional: true
 
   validates :type,
             presence: true,
             inclusion: %w[ManualServiceRelationship ServiceRelationship RequiredServiceRelationship]
+
+  def set_type
+    self.type = type
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Service, backend: true do
   it "has related services" do
     s1, s2, s3 = create_list(:service, 3)
 
-    ServiceRelationship.create(source: s1, target: s2, type: "ServiceRelationship")
-    ServiceRelationship.create(source: s1, target: s3, type: "ServiceRelationship")
+    ServiceRelationship.create!(source: s1, target: s2, type: "ServiceRelationship")
+    ServiceRelationship.create!(source: s1, target: s3, type: "ServiceRelationship")
 
     expect(s1.related_services).to contain_exactly(s2, s3)
   end

--- a/spec/services/service/pc_create_or_update_spec.rb
+++ b/spec/services/service/pc_create_or_update_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Service::PcCreateOrUpdate, backend: true do
   end
 
   describe "#succesfull responses" do
-    it "should create new service with new default offer" do
+    it "should create new service without new default offer" do
       provider = create(:provider, name: "Test Provider 3")
       provider_tp = create(:provider, name: "Test Provider tp")
       create(:provider_source, source_type: "eosc_registry", eid: "new.prov", provider: provider)


### PR DESCRIPTION
Fixed model ServiceRelationship with unnecessary foreign_type and polymorphic flag.
This caused every ServiceRelationship to have a type `Service` instead of the kind of relationship.