### PR TITLE
feat:[#65] Add status changes to multiple objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please view this file on the master branch, on stable branches it's out of date.
 - Environmental variable to hide recommendation panel (`SHOW_RECOMMENDATION_PANEL`) (@maria-j-k)
 - Unit to the constant offer parameter (@gorreck888)
 - `Save as draft` and `Duplicate` features for offer form (@maria-j-k) 
+- Publish/Suspend/Unpublish actions for multiple Providers and Catalogues (@goreck888, @jarekzet)
 
 ### Changed
 - MarketplaceLocation renamed to ResearchActivity (@maria-j-k)

--- a/app/assets/stylesheets/_bootstrap-customizations.scss
+++ b/app/assets/stylesheets/_bootstrap-customizations.scss
@@ -2660,7 +2660,7 @@ label[data-multicheckbox].small {
 .backoffice-list {
   .list-group-item {
     border: none;
-    padding: 0.45rem 1rem;
+    padding: 0.25rem 1rem;
 
     &:nth-child(even) {
       background: $alert-bg;
@@ -2692,6 +2692,8 @@ label[data-multicheckbox].small {
     .status {
       margin: 0;
       text-align: center;
+      width: 100%;
+      display: inline-block;
       color: $palette-white;
       font-size: 12px;
       padding: 6px 8px;
@@ -2721,6 +2723,50 @@ label[data-multicheckbox].small {
 
     &.heading-row {
       font-weight: 600;
+
+      .col {
+        &:last-child {
+          padding: 0;
+        }
+      }
+    }
+
+    &.providers {
+      .row {
+        .col {
+          &:first-child {
+            flex: 0 0 20px;
+            display: flex;
+            align-items: center;
+          }
+
+          &:nth-child(2) {
+            font-size: 14px !important;
+
+            a {
+              font-size: 14px;
+            }
+          }
+
+          &:nth-child(3) {
+            flex: 0 0 220px;
+            font-size: 14px;
+          }
+
+          &:nth-child(4) {
+            flex: 0 0 210px;
+            font-size: 14px;
+          }
+
+          &:last-child {
+            flex: 0 0 115px;
+          }
+
+          .form-check-input {
+            margin: 0;
+          }
+        }
+      }
     }
   }
 
@@ -4776,6 +4822,17 @@ label[data-multicheckbox].small {
 
 // scss-lint:disable all
 .modal-content {
+  border: none;
+  border-radius: 8px;
+
+  .backoffice-list {
+    .list-group-item {
+      .status {
+        padding: 4px 8px;
+      }
+    }
+  }
+
   .form-control,
   .project_scientific_domains {
     width: 100%;
@@ -5099,9 +5156,18 @@ abbr[title] {
 
 .modal {
   overflow-y: auto;
+  background: $modal-overlay-bg;
 
   .modal-dialog {
     max-width: 570px;
+
+    &.wide {
+      max-width: 1280px;
+    }
+
+    &.medium {
+      max-width: 825px;
+    }
 
     &.new-feature {
       max-width: 885px;
@@ -5134,16 +5200,16 @@ abbr[title] {
 
   .modal-header {
     border: none;
-    padding: 1.5rem 1rem 1rem;
+    padding: 2.4rem 1.5rem 1rem;
 
     h3 {
       margin: 0;
-      font-size: 22px;
-      font-weight: 600;
+      font-size: 24px;
+      font-weight: 500;
     }
 
     .close {
-      font-size: 45px;
+      font-size: 38px;
       padding-top: 5px;
       padding-bottom: 0;
       color: $palette-solid-100;
@@ -5151,8 +5217,28 @@ abbr[title] {
   }
 
   .modal-body {
-    padding-top: 0;
-    padding-bottom: 25px;
+    padding: 0 1.5rem 1.5rem;
+
+    .pagy-bootstrap {
+      justify-content: center;
+    }
+
+    .actions-row {
+      justify-content: space-between;
+      display: flex;
+      width: 100%;
+
+      .btn-secondary,
+      .btn-primary {
+        font-size: 1rem;
+        width: 30%;
+      }
+
+      .btn-secondary {
+        border: 1px solid $custom-16;
+        color: $custom-16;
+      }
+    }
 
     .modal-info {
       background: $border-header url("ico_eosccloud_grey.svg") 20px 50% no-repeat;
@@ -5193,6 +5279,61 @@ abbr[title] {
     float: left;
     opacity: 1;
   }
+}
+
+.confirm-modal {
+  flex-direction: column;
+  border: none;
+  border-radius: 8px;
+  width: 600px;
+  padding: 15px 24px 40px;
+  overflow: hidden;
+
+  &::backdrop {
+    background: $modal-overlay-bg-strong;
+  }
+
+  .close {
+    span {
+      font-size: 30px;
+      line-height: 20px;
+      display: inline-block;
+    }
+  }
+
+  .confirm-title {
+    font-size: 24px;
+    font-weight: 500;
+  }
+
+  .confirm-body {
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 150%;
+    color: $body-color;
+  }
+
+  .modal-actions {
+    justify-content: space-between;
+    display: flex;
+    margin-top: 40px;
+    width: 100%;
+
+    .btn {
+      width: 48%;
+    }
+
+    .btn-secondary {
+      border: 1px solid $custom-16;
+      color: $custom-16;
+    }
+  }
+}
+
+.subsection {
+  margin: 0;
+  font-weight: 300;
+  padding-bottom: 0;
 }
 
 .additional-information {
@@ -8002,7 +8143,8 @@ abbr[title] {
     }
   }
 
-  .btn-primary {
+  .btn-primary,
+  .btn-secondary {
     font-size: 14px;
     padding: 0.62rem 1.3rem;
 
@@ -8666,6 +8808,26 @@ footer {
   }
 }
 // scss-lint:enable all
+
+.selected-menu {
+  height: 24px;
+  border: 1px solid $landing-01;
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+
+  a {
+    max-width: 100% !important;
+    font-size: 11px;
+    width: 100%;
+    text-align: center;
+    line-height: 22px;
+  }
+
+  &:hover {
+    background: $alert-bg;
+  }
+}
 
 .searchbar {
   &.whitelabel {

--- a/app/assets/stylesheets/_ref_mobile.scss
+++ b/app/assets/stylesheets/_ref_mobile.scss
@@ -248,6 +248,64 @@
 }
 
 @media (max-width: 768px) {
+  .backoffice-list {
+    .list-group-item {
+      &.providers {
+        .row {
+          justify-content: flex-end;
+
+          .col {
+            &:first-child {
+              flex: 0 0 20px;
+              display: flex;
+              align-items: center;
+            }
+
+            &:nth-child(2) {
+              font-size: 13px !important;
+
+              a {
+                font-size: 13px;
+              }
+            }
+
+            &:nth-child(3) {
+              flex: 0 0 90%;
+              font-size: 11px;
+            }
+
+            &:nth-child(4) {
+              flex: 0 0 40%;
+              font-size: 13px;
+            }
+
+            &:last-child {
+              flex: 0 0 50%;
+            }
+
+            .form-check-input {
+              margin: 0;
+            }
+          }
+        }
+      }
+
+      &.heading-row {
+        .row {
+          justify-content: space-between;
+
+          .col {
+            &:nth-child(2),
+            &:nth-child(3),
+            &:nth-child(4) {
+              display: none;
+            }
+          }
+        }
+      }
+    }
+  }
+
   .empty-information {
     padding: 18px;
 

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -191,6 +191,8 @@ $custom-25: #1d4e3b;
 $custom-26: #caf6d4;
 $custom-27: #f8f8ff;
 $custom-28: rgb(0, 0, 0, 0.4);
+$modal-overlay-bg: rgb(0, 0, 0, 0.4);
+$modal-overlay-bg-strong: rgb(0, 0, 0, 0.6);
 
 $landing-01: #4c505a;
 $landing-02: #020a20;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,4 +30,3 @@
 @import "shepherd";
 @import "jira_collector";
 @import "actiontext";
-@import "trix.css";

--- a/app/components/presentable/list_component.html.haml
+++ b/app/components/presentable/list_component.html.haml
@@ -1,0 +1,4 @@
+%ul.list-group.backoffice-list.mt-3.mb-3
+  = render "components/presentable/list_component/list_header", klass: @klass, form: @form
+  - @collection.each do |obj|
+    = render "components/presentable/list_component/list_item", obj: obj, klass: @klass

--- a/app/components/presentable/list_component.rb
+++ b/app/components/presentable/list_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "action_view/helpers"
+
+class Presentable::ListComponent < ApplicationComponent
+  include ActionView::Helpers
+  def initialize(collection:)
+    super()
+    @collection = collection
+    @klass = collection.model.name.underscore
+  end
+end

--- a/app/components/presentable/status_actions_component.html.haml
+++ b/app/components/presentable/status_actions_component.html.haml
@@ -10,8 +10,10 @@
           = link_to _("Publish"),
               send("backoffice_#{@object_type}_publish_path", @object),
               class: "btn btn-primary",
-              data: { "turbo-confirm": _("Are you sure you want to publish this #{@object_type}?"),
-              e2e: "publish-btn", "turbo-method": :post }
+              data: { turbo_confirm: "Confirm to publish",
+              confirm_details: "Are you sure you want to publish this #{@object_type}?",
+              confirm_button: "Publish",
+              e2e: "publish-btn", turbo_method: :post }
         - if @suspend
           = link_to _("Suspend"),
               suspend_path,

--- a/app/components/turbo_modal_component.html.haml
+++ b/app/components/turbo_modal_component.html.haml
@@ -3,7 +3,7 @@
   "turbo-modal-target": "modal",
   action: "turbo:submit-end->turbo-modal#submitEnd keyup@window->turbo-modal#closeWithKeyboard click@window->turbo-modal#closeBackground"
     } }
-    .modal-dialog{ role: "document" }
+    .modal-dialog{ role: "document", class: @custom_style }
       .modal-content
         .modal-header
           %h3#form-modal-title.modal-title= @title
@@ -16,6 +16,3 @@
 
         .modal-footer
           = yield_content!(:buttons) if content_for?(:buttons)
-          %button.close.close-link.pl-3.pr-3{ data: { action: "turbo-modal#hideModal" }, type: "button" }
-            %span
-              = _("Close")

--- a/app/components/turbo_modal_component.rb
+++ b/app/components/turbo_modal_component.rb
@@ -4,8 +4,9 @@ class TurboModalComponent < ApplicationComponent
   include ApplicationHelper
   include Turbo::FramesHelper
 
-  def initialize(title:)
+  def initialize(title:, custom_style: nil)
     super()
     @title = title
+    @custom_style = custom_style
   end
 end

--- a/app/controllers/backoffice/application_controller.rb
+++ b/app/controllers/backoffice/application_controller.rb
@@ -4,7 +4,7 @@ class Backoffice::ApplicationController < ApplicationController
   before_action :authenticate_user!
   before_action :backoffice_authorization!
 
-  layout "backoffice"
+  layout -> { turbo_frame_request? ? "turbo_rails/frame" : "backoffice" }
 
   def policy_scope(scope)
     super([:backoffice, scope])

--- a/app/controllers/backoffice/catalogues/publishes_controller.rb
+++ b/app/controllers/backoffice/catalogues/publishes_controller.rb
@@ -4,12 +4,15 @@ class Backoffice::Catalogues::PublishesController < Backoffice::ApplicationContr
   before_action :find_and_authorize
 
   def create
-    if Catalogue::Publish.call(@catalogue)
-      flash[:notice] = _("Catalogue published successfully")
-    else
-      flash[:alert] = "Catalogue not published. Reason: #{@catalogue.errors.full_messages.join(", ")}"
+    respond_to do |format|
+      if Catalogue::Publish.call(@catalogue)
+        flash[:notice] = _("Catalogue published successfully")
+      else
+        flash[:alert] = "Catalogue not published. Reason: #{@catalogue.errors.full_messages.join(", ")}"
+      end
+      format.turbo_stream
+      format.html { redirect_to backoffice_catalogue_path(@catalogue) }
     end
-    redirect_to backoffice_catalogue_path(@catalogue)
   end
 
   private

--- a/app/controllers/backoffice/catalogues/unpublishes_controller.rb
+++ b/app/controllers/backoffice/catalogues/unpublishes_controller.rb
@@ -5,13 +5,16 @@ class Backoffice::Catalogues::UnpublishesController < Backoffice::ApplicationCon
 
   def create
     result = params[:suspend] ? Catalogue::Suspend.call(@catalogue) : Catalogue::Unpublish.call(@catalogue)
-    if result
-      flash[:notice] = "Catalogue #{params[:suspend] ? "suspended" : "unpublished"} successfully"
-    else
-      flash[:alert] = "Catalogue not #{params[:suspend] ? "suspended" : "unpublished"}. " +
-        "Reason: #{@catalogue.errors.full_messages.join(", ")}"
+    respond_to do |format|
+      if result
+        flash[:notice] = "Catalogue #{params[:suspend] ? "suspended" : "unpublished"} successfully"
+      else
+        flash[:alert] = "Catalogue not #{params[:suspend] ? "suspended" : "unpublished"}. " +
+          "Reason: #{@catalogue.errors.full_messages.join(", ")}"
+      end
+      format.turbo_stream
+      format.html { redirect_to backoffice_catalogue_path(@catalogue) }
     end
-    redirect_to backoffice_catalogue_path(@catalogue)
   end
 
   private

--- a/app/controllers/backoffice/providers/publishes_controller.rb
+++ b/app/controllers/backoffice/providers/publishes_controller.rb
@@ -4,12 +4,15 @@ class Backoffice::Providers::PublishesController < Backoffice::ApplicationContro
   before_action :find_and_authorize
 
   def create
-    if Provider::Publish.call(@provider)
-      flash[:notice] = _("Provider published successfully")
-    else
-      flash[:alert] = "Provider not published. Reason: #{@provider.errors.full_messages.join(", ")}"
+    respond_to do |format|
+      if Provider::Publish.call(@provider)
+        flash[:notice] = _("Provider published successfully")
+      else
+        flash[:alert] = "Provider not published. Reason: #{@provider.errors.full_messages.join(", ")}"
+      end
+      format.turbo_stream
+      format.html { redirect_to backoffice_provider_path(@provider) }
     end
-    redirect_to backoffice_provider_path(@provider)
   end
 
   private

--- a/app/controllers/backoffice/providers/unpublishes_controller.rb
+++ b/app/controllers/backoffice/providers/unpublishes_controller.rb
@@ -5,13 +5,16 @@ class Backoffice::Providers::UnpublishesController < Backoffice::ApplicationCont
 
   def create
     result = params[:suspend] ? Provider::Suspend.call(@provider) : Provider::Unpublish.call(@provider)
-    if result
-      flash[:notice] = "Provider #{params[:suspend] ? "suspended" : "unpublished"} successfully"
-    else
-      flash[:alert] = "Provider not #{params[:suspend] ? "suspended" : "unpublished"}. " +
-        "Reason: #{@provider.errors.full_messages.join(", ")}"
+    respond_to do |format|
+      if result
+        flash[:notice] = "Provider #{params[:suspend] ? "suspended" : "unpublished"} successfully"
+      else
+        flash[:alert] = "Provider not #{params[:suspend] ? "suspended" : "unpublished"}. " +
+          "Reason: #{@provider.errors.full_messages.join(", ")}"
+      end
+      format.turbo_stream
+      format.html { redirect_to backoffice_provider_path(@provider) }
     end
-    redirect_to backoffice_provider_path(@provider)
   end
 
   private

--- a/app/controllers/backoffice/providers_controller.rb
+++ b/app/controllers/backoffice/providers_controller.rb
@@ -35,7 +35,7 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
     authorize(@provider)
 
     if valid_model_and_urls? && @provider.save(validate: false)
-      redirect_to backoffice_provider_path(@provider), notice: "New provider created successfully"
+      redirect_to backoffice_provider_path(@provider, page: params[:page]), notice: "New provider created successfully"
     else
       catalogue_scope
       render :new, status: :unprocessable_entity
@@ -76,10 +76,13 @@ class Backoffice::ProvidersController < Backoffice::ApplicationController
   def destroy
     respond_to do |format|
       if Provider::Delete.call(@provider)
+        @provider.reload
         notice = "Provider removed successfully"
-        format.html { redirect_to backoffice_providers_path, notice: notice }
+        format.turbo_stream { flash.now[:notice] = notice }
+        format.html { redirect_to backoffice_providers_path(page: params[:page]), notice: notice }
       else
         alert = "This Provider has services connected to it, therefore is not possible to remove it."
+        format.turbo_stream { flash.now[:alert] = alert }
         format.html { redirect_to backoffice_provider_path(@provider), alert: alert }
       end
     end

--- a/app/controllers/backoffice/statuses/catalogues_controller.rb
+++ b/app/controllers/backoffice/statuses/catalogues_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Backoffice::Statuses::CataloguesController < Backoffice::ApplicationController
+  include StatusChangeHelper
+
+  def create
+    @catalogues = Catalogue.where(id: params[:catalogue_ids])
+    respond_to do |format|
+      @catalogues.each do |catalogue|
+        next if action_for(catalogue, params[:commit]).call(catalogue)
+        alert =
+          "Catalogue #{catalogue.name} was not #{params[:commit]}ed. " +
+            "Reason: #{catalogue.errors.full_messages.to_sentence}"
+        format.turbo_stream { flash.now[:alert] = alert and return nil }
+        format.html { redirect_to backoffice_catalogues_path(page: params[:page]), alert: alert and return nil }
+      end
+      @catalogues.reload
+      notice = "Selected Catalogues are successfully #{params[:commit]}ed."
+      format.turbo_stream { flash.now[:notice] = notice }
+      format.html { redirect_to backoffice_catalogues_path(page: params[:page]), notice: notice }
+    end
+  end
+end

--- a/app/controllers/backoffice/statuses/providers_controller.rb
+++ b/app/controllers/backoffice/statuses/providers_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Backoffice::Statuses::ProvidersController < Backoffice::ApplicationController
+  include StatusChangeHelper
+  def create
+    @providers = Provider.where(id: params[:provider_ids])
+    respond_to do |format|
+      @providers.each do |provider|
+        next if action_for(provider, params[:commit]).call(provider)
+        alert =
+          "Provider #{provider.name} was not #{params[:commit]}ed. " +
+            "Reason: #{provider.errors.full_messages.to_sentence}"
+        format.turbo_stream { flash.now[:alert] = alert }
+        format.html { redirect_to backoffice_statuses_providers_path, alert: alert and return nil }
+      end
+      @providers.reload
+      notice = "Selected Providers are successfully #{params[:commit]}ed."
+      format.turbo_stream { flash.now[:notice] = notice }
+      format.html { redirect_to backoffice_providers_path, notice: notice }
+    end
+  end
+end

--- a/app/controllers/concerns/service/searchable.rb
+++ b/app/controllers/concerns/service/searchable.rb
@@ -18,18 +18,15 @@ module Service::Searchable
     services =
       Service.search(
         query,
-        **common_params.merge(
-          where: filter_constr(filters, scope_constr(scope, category_constr)),
-          page: params[:page],
-          per_page: "#{per_page(additionals_size)}",
-          order: ordering,
-          highlight: {
-            tag: "<mark>"
-          },
-          scope_results: ->(r) do
-            r.includes(:scientific_domains, :providers, :target_users, :offers).with_attached_logo
-          end
-        )
+        **common_params,
+        where: filter_constr(filters, scope_constr(scope, category_constr)),
+        page: params[:page],
+        per_page: "#{per_page(additionals_size)}",
+        order: ordering,
+        highlight: {
+          tag: "<mark>"
+        },
+        scope_results: ->(r) { r.includes(:scientific_domains, :providers, :target_users, :offers).with_attached_logo }
       )
 
     offers =
@@ -53,18 +50,20 @@ module Service::Searchable
     filters -= [current_filter]
     Service.search(
       query,
-      **common_params.merge(
-        where: filter_constr(filters, scope_constr(scope, category_constr)),
-        aggs: [current_filter.index],
-        load: false
-      )
+      **common_params,
+      where: filter_constr(filters, scope_constr(scope, category_constr)),
+      aggs: [current_filter.index],
+      load: false
     )
   end
 
   def search_for_categories(scope, filters)
     Service.search(
       query,
-      **common_params.merge(where: filter_constr(filters, scope_constr(scope)), aggs: [:categories], load: false)
+      **common_params,
+      where: filter_constr(filters, scope_constr(scope)),
+      aggs: [:categories],
+      load: false
     )
   end
 

--- a/app/helpers/confirm_helper.rb
+++ b/app/helpers/confirm_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ConfirmHelper
+  def fill(singular)
+    singular ? "this" : "these"
+  end
+  def publish_message(type = "rovider", singular: true)
+    type = type.pluralize unless singular
+    "Publishing #{fill(singular)} #{type} will make it visible to the users. " + "Do you want to continue?"
+  end
+
+  def unpublish_message(type = "provider", singular: true)
+    type = type.pluralize unless singular
+    "Unpublishing #{fill(singular)} #{type} will make it not longer visible to the users. " + "Do you want to continue?"
+  end
+
+  def suspend_message(type = "provider", singular: true)
+    type = type.pluralize unless singular
+    "Suspending #{fill(singular)} #{type} will temporarily disable it. Do you want to continue?"
+  end
+
+  def delete_message(type = "provider", singular: false)
+    type = type.pluralize unless singular
+    "Deleting #{fill(singular)} #{type} is permanently and cannot be undone. Do you want to continue?"
+  end
+end

--- a/app/helpers/status_change_helper.rb
+++ b/app/helpers/status_change_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module StatusChangeHelper
+  ACTIONS = { Publish: "Publish", Suspend: "Suspend", Unpublish: "Unpublish" }.freeze
+
+  def action_for(object, action)
+    "#{object.class}::#{ACTIONS[action.to_sym]}".constantize
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,5 +11,8 @@ import "./controllers";
 
 import jquery from "jquery";
 import "@hotwired/turbo-rails";
+import TC from "@rolemodel/turbo-confirm";
 
 window.$ = window.jQuery = jquery;
+
+TC.start({ activeClass: "d-flex" });

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -49,6 +49,9 @@ application.register("form", FormController);
 import HomePageController from "./home_page_controller";
 application.register("home-page", HomePageController);
 
+import ListController from "./list_controller";
+application.register("list", ListController);
+
 import MapController from "./map_controller";
 application.register("map", MapController);
 

--- a/app/javascript/controllers/list_controller.js
+++ b/app/javascript/controllers/list_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="list"
+export default class extends Controller {
+  static targets = ["name", "checkbox", "selectedMenu", "itemMenu", "checkAll"];
+  connect() {}
+
+  toggleAll(event) {
+    const target = event.currentTarget;
+    this.checkboxTargets.forEach((el) => (el.checked = target.checked));
+    this.toggleActions();
+  }
+
+  toggleCurrent(event) {
+    event.preventDefault();
+    const target = document.getElementById(event.currentTarget.dataset.value);
+    target.checked = !target.checked;
+    this.toggleActions();
+  }
+
+  toggleActions(event) {
+    if (this.checkboxTargets.filter((el) => el.checked).length < 2) {
+      this.selectedMenuTarget.classList.add("d-none");
+      this.itemMenuTargets.forEach((el) => el.classList.remove("d-none"));
+    } else {
+      this.selectedMenuTarget.classList.remove("d-none");
+      this.itemMenuTargets.forEach((el) => el.classList.add("d-none"));
+    }
+  }
+
+  checkIndetermination(event) {
+    const state = event.currentTarget.checked;
+    if (this.checkboxTargets.some((e) => e.checked !== state)) {
+      this.checkAllTarget.checked = false;
+      this.checkAllTarget.indeterminate = true;
+      this.checkAllTarget.classList.add("indeterminate");
+      return;
+    }
+    this.checkAllTarget.indeterminate = false;
+    this.checkAllTarget.classList.remove("indeterminate");
+    this.checkAllTarget.checked = state;
+  }
+
+  reset(event) {
+    this.checkAllTarget.checked = false;
+    this.checkAllTarget.indeterminate = false;
+  }
+}

--- a/app/policies/backoffice/application_policy.rb
+++ b/app/policies/backoffice/application_policy.rb
@@ -55,6 +55,10 @@ class Backoffice::ApplicationPolicy < ApplicationPolicy
     actionable?
   end
 
+  def management_role?
+    service_portfolio_manager? || data_administrator?
+  end
+
   private
 
   def service_portfolio_manager?
@@ -71,9 +75,5 @@ class Backoffice::ApplicationPolicy < ApplicationPolicy
 
   def actionable?
     access? && !record.deleted?
-  end
-
-  def management_role?
-    service_portfolio_manager? || data_administrator?
   end
 end

--- a/app/views/backoffice/catalogues/_catalogue.html.haml
+++ b/app/views/backoffice/catalogues/_catalogue.html.haml
@@ -1,0 +1,23 @@
+= turbo_frame_tag catalogue do
+  %li.list-group-item.providers
+    .row
+      .col-12.col-md-8
+        = link_to catalogue.name, backoffice_catalogue_path(catalogue,
+                params: { page: params[:page] } || {}), class: "catalogue-name",
+                data: { turbo_frame: "_top" }
+      .col-12.col-md-2.text-center
+        %span.status{ class: catalogue.status }
+          = catalogue.status
+      .col-12.col-md-2
+        .actions
+          - if policy([:backoffice, catalogue]).destroy?
+            = link_to backoffice_catalogue_path(catalogue.id),
+                          data: { "turbo-confirm": action_prompt("catalogue", "remove"), "turbo-method": :delete },
+                          class: "delete-icon float-right" do
+              %i.far.fa-trash-alt
+
+            - if policy([:backoffice, catalogue]).edit?
+              = link_to _("Edit"),
+                          edit_backoffice_catalogue_path(catalogue),
+                          data: { turbo_frame: "_top" },
+                          class: "edit-btn float-right mr-4"

--- a/app/views/backoffice/catalogues/destroy.turbo_stream.haml
+++ b/app/views/backoffice/catalogues/destroy.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@catalogue.reload,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @catalogue, klass: "catalogue" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/catalogues/index.html.haml
+++ b/app/views/backoffice/catalogues/index.html.haml
@@ -22,30 +22,6 @@
                     class: "btn btn-primary",
                     "data-e2e": "add-new-catalogue"
         .clearfix
-    %ul.list-group.backoffice-list.mt-3.mb-3{ "data-e2e": "backoffice-catalogues-list" }
-      %li.list-group-item.heading-row
-        .row
-          .col-12.col-md-8 Name
-          .col-12.col-md-2.text-center Status
-          .col-12.col-md-2
-      - @catalogues.each do |catalogue|
-        %li.list-group-item.providers
-          .row
-            .col-12.col-md-8
-              = link_to catalogue.name, backoffice_catalogue_path(catalogue,
-              params: { page: params[:page] } || {}), class: "catalogue-name"
-            .col-12.col-md-2.text-center
-              %span.status{ class: catalogue.status }
-                = catalogue.status
-            .col-12.col-md-2
-              .actions
-                - if policy([:backoffice, catalogue]).destroy?
-                  = link_to backoffice_catalogue_path(catalogue.id),
-                        data: { "turbo-confirm": action_prompt("catalogue", "remove"), "turbo-method": :delete },
-                        class: "delete-icon float-right" do
-                    %i.far.fa-trash-alt
-
-                  - if policy([:backoffice, catalogue]).edit?
-                    = link_to _("Edit"),
-                        edit_backoffice_catalogue_path(catalogue),
-                        class: "edit-btn float-right mr-4"
+    = turbo_frame_tag "checkbox_form" do
+      = render "backoffice/statuses/form", collection: @catalogues, pagy: @pagy,
+        form_path: backoffice_statuses_catalogues_path

--- a/app/views/backoffice/catalogues/publishes/create.turbo_stream.haml
+++ b/app/views/backoffice/catalogues/publishes/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@catalogue.reload,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @catalogue, klass: "catalogue" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/catalogues/unpublishes/create.turbo_stream.haml
+++ b/app/views/backoffice/catalogues/unpublishes/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@catalogue.reload,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @catalogue, klass: "catalogue" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/common_parts/form/_status_actions.html.haml
+++ b/app/views/backoffice/common_parts/form/_status_actions.html.haml
@@ -1,0 +1,25 @@
+.actions-row.mt-5
+  = f.button "Suspend selected",
+    name: "commit",
+    value: "Suspend",
+    disabled: true,
+    class: "btn btn-secondary",
+    data: { turbo_confirm: "Confirm to suspend",
+    confirm_details: "Are you sure you want to suspend selected #{type}s?",
+    confirm_button: "Suspend" }
+  = f.button "Unpublish selected",
+    name: "commit",
+    value: "Unpublish",
+    disabled: true,
+    class: "btn btn-secondary",
+    data: { turbo_confirm: "Confirm to unpublish", list_target: "btn",
+    confirm_details: "Are you sure you want to unpublish selected #{type}s?",
+    confirm_button: "Unpublish" }
+  = f.button "Publish selected",
+    name: "commit",
+    value: "Publish",
+    disabled: true,
+    class: "btn btn-primary",
+    data: { turbo_confirm: "Confirm to publish", list_target: "btn",
+    confirm_details: "Are you sure you want to publish selected #{type}s?",
+    confirm_button: "Publish" }

--- a/app/views/backoffice/providers/_provider.html.haml
+++ b/app/views/backoffice/providers/_provider.html.haml
@@ -1,20 +1,23 @@
-%li.list-group-item.providers{ id: "provider-#{provider.id}" }
-  .row
-    .col-12.col-md-8
-      = link_to provider.name, backoffice_provider_path(provider,
-            params: { page: params[:page] } || {}), class: "provider-name"
-    .col-12.col-md-2.text-center
-      %span.status{ class: provider.status }
-        = provider.status
-    .col-12.col-md-2
-      .actions
-        - if policy([:backoffice, provider]).destroy?
-          = link_to backoffice_provider_path(provider.id),
-                    data: { "turbo-confirm": action_prompt("provider", "remove"), "turbo-method": :delete },
-                    class: "delete-icon float-right" do
-            %i.far.fa-trash-alt
+= turbo_frame_tag provider do
+  %li.list-group-item.providers{ id: "provider-#{provider.id}" }
+    .row
+      .col-12.col-md-8
+        = link_to provider.name, backoffice_provider_path(provider,
+              params: { page: params[:page] } || {}), class: "#{provider}-name",
+              data: { turbo_frame: "_top" }
+      .col-12.col-md-2.text-center
+        %span.status{ class: provider.status }
+          = provider.status
+      .col-12.col-md-2
+        .actions
+          - if policy([:backoffice, provider]).destroy?
+            = link_to backoffice_provider_path(provider.id),
+                      data: { "turbo-confirm": action_prompt("provider", "remove"), "turbo-method": :delete },
+                      class: "delete-icon float-right" do
+              %i.far.fa-trash-alt
 
-        - if policy([:backoffice, provider]).edit?
-          = link_to _("Edit"),
-                    edit_backoffice_provider_path(provider),
-                    class: "edit-btn float-right mr-4"
+          - if policy([:backoffice, provider]).edit?
+            = link_to _("Edit"),
+                      edit_backoffice_provider_path(provider),
+                      data: { turbo_frame: "_top" },
+                      class: "edit-btn float-right mr-4"

--- a/app/views/backoffice/providers/_provider_prompt.html.haml
+++ b/app/views/backoffice/providers/_provider_prompt.html.haml
@@ -1,0 +1,55 @@
+.row
+  .become-provider.col-12.col-md-9.m-auto
+    %h1 Become a Provider
+    %h4
+      Share your resources to reach
+      %br
+      the Marketplace users.
+    .backoffice-arrow
+      = image_tag "backoffice-arrow.svg"
+    .row.mb-5
+      .col-12
+        = link_to _("+ Create a Provider"),
+                    new_backoffice_provider_path,
+                    class: "btn btn-primary float-right",
+                    "data-e2e": "add-new-provider"
+
+    %h2 As a Provider
+
+    %a.backoffice-item.add-tem{ href: "#" }
+      .backoffice-image
+        = image_tag "backoffice-01.svg"
+      .backoffice-item-txt
+        .backoffice-item-title Add Your Service
+        .backoffice-item-desc
+          Create, delete, and update their services at any time. Gain full control and manage your offerings with ease.
+    %a.backoffice-item.create-offer{ href: "#" }
+      .backoffice-image
+        = image_tag "backoffice-02.svg"
+      .backoffice-item-txt
+        .backoffice-item-title Create an Offer
+        .backoffice-item-desc
+          Add new offers, modify existing ones, and monitor their statuses. Stay responsive to users
+          demands and keep your offers up-to-date.
+
+    %h2.mt-5 Organise your Providers
+
+    %a.backoffice-item.add-tem{ href: "#" }
+      .backoffice-image
+        = image_tag "backoffice-03.svg"
+      .backoffice-item-txt
+        .backoffice-item-title Group Providers into Catalogues
+        .backoffice-item-desc
+          Use catalogues to manage and organise multiple providers. Add, remove, and arrange them
+          to keep your marketplace in order.
+
+    %h2.text-center Join the Marketplace
+    %h4.text-center
+      Join our Providers to explore how to onboard
+      %br
+      services and create offers.
+    .row.text-center
+      = link_to _("+ Create a Provider"),
+                    new_backoffice_provider_path,
+                    class: "btn btn-primary m-auto",
+                    "data-e2e": "add-new-provider"

--- a/app/views/backoffice/providers/destroy.turbo_stream.haml
+++ b/app/views/backoffice/providers/destroy.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@provider,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @provider, klass: "provider" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/providers/index.html.haml
+++ b/app/views/backoffice/providers/index.html.haml
@@ -3,62 +3,7 @@
 
 .container.p-0.backoffice
   - if @providers.blank?
-    .row
-      .become-provider.col-12.col-md-9.m-auto
-        %h1 Become a Provider
-        %h4
-          Share your resources to reach
-          %br
-          the Marketplace users.
-        .backoffice-arrow
-          = image_tag "backoffice-arrow.svg"
-        .row.mb-5
-          .col-12
-            = link_to _("+ Create a Provider"),
-                      new_backoffice_provider_path,
-                      class: "btn btn-primary float-right",
-                      "data-e2e": "add-new-provider"
-
-        %h2 As a Provider
-
-        %a.backoffice-item.add-tem{ href: "#" }
-          .backoffice-image
-            = image_tag "backoffice-01.svg"
-          .backoffice-item-txt
-            .backoffice-item-title Add Your Service
-            .backoffice-item-desc
-              Create, delete, and update their services at any time. Gain full control and manage your offerings with ease.
-        %a.backoffice-item.create-offer{ href: "#" }
-          .backoffice-image
-            = image_tag "backoffice-02.svg"
-          .backoffice-item-txt
-            .backoffice-item-title Create an Offer
-            .backoffice-item-desc
-              Add new offers, modify existing ones, and monitor their statuses. Stay responsive to users
-              demands and keep your offers up-to-date.
-
-        %h2.mt-5 Organise your Providers
-
-        %a.backoffice-item.add-tem{ href: "#" }
-          .backoffice-image
-            = image_tag "backoffice-03.svg"
-          .backoffice-item-txt
-            .backoffice-item-title Group Providers into Catalogues
-            .backoffice-item-desc
-              Use catalogues to manage and organise multiple providers. Add, remove, and arrange them
-              to keep your marketplace in order.
-
-        %h2.text-center Join the Marketplace
-        %h4.text-center
-          Join our Providers to explore how to onboard
-          %br
-          services and create offers.
-        .row.text-center
-          = link_to _("+ Create a Provider"),
-                      new_backoffice_provider_path,
-                      class: "btn btn-primary m-auto",
-                      "data-e2e": "add-new-provider"
-
+    = render "backoffice/providers/provider_prompt"
   - else
     %h1
       = _("Providers")
@@ -69,13 +14,6 @@
                     class: "btn btn-primary",
                     "data-e2e": "add-new-provider"
         .clearfix
-
-    %ul.list-group.backoffice-list.mt-3.mb-3{ "data-e2e": "backoffice-providers-list" }
-      %li.list-group-item.heading-row
-        .row
-          .col-12.col-md-8 Name
-          .col-12.col-md-2.text-center Status
-          .col-12.col-md-2
-      = render partial: "backoffice/providers/provider", collection: @providers, as: :provider
-
-    = (pagy_bootstrap_nav @pagy).html_safe
+    = turbo_frame_tag "checkbox_form" do
+      = render "backoffice/statuses/form", collection: @providers, pagy: @pagy,
+        form_path: backoffice_statuses_providers_path

--- a/app/views/backoffice/providers/publishes/create.turbo_stream.haml
+++ b/app/views/backoffice/providers/publishes/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@provider.reload,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @provider, klass: "provider" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/providers/unpublishes/create.turbo_stream.haml
+++ b/app/views/backoffice/providers/unpublishes/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+= turbo_stream.replace(@provider.reload,
+                       partial: "components/presentable/list_component/item_details",
+                       locals: { obj: @provider, klass: "provider" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/statuses/_form.html.haml
+++ b/app/views/backoffice/statuses/_form.html.haml
@@ -1,0 +1,33 @@
+= form_with url: form_path, method: :post,
+  html: { data: { e2e: "backoffice-providers-list", controller: "form list",
+  form_target: "form", turbo_frame: "checkbox_form", turbo: true } } do |f|
+  = render Presentable::ListComponent.new(collection: collection)
+  = (pagy_bootstrap_nav pagy).html_safe
+  .d-none
+    - type = collection.model.name.underscore
+    = f.hidden_field :page, value: pagy.page
+    = f.button _("Publish selected"),
+          id: "publish-btn",
+          name: "commit",
+          value: "Publish",
+          class: "dropdown-item",
+          data: { action: "list#reset", turbo_method: :post, turbo_confirm: _("Confirm to publish"),
+            confirm_details: publish_message(type, singular: false), confirm_button: _("Publish #{type}s") }
+    = f.button _("Suspend selected"),
+          id: "suspend-btn",
+          name: "commit",
+          value: "Suspend",
+          class: "dropdown-item",
+          data: { action: "list#reset", turbo_method: :post,
+          turbo_confirm: _("Confirm to suspend"),
+          confirm_details: suspend_message(type, singular: false),
+          confirm_button: _("Suspend #{type}s") }
+    = f.button _("Unpublish selected"),
+          id: "unpublish-btn",
+          name: "commit",
+          value: "Unpublish",
+          class: "dropdown-item",
+          data: { action: "list#reset", turbo_method: :post,
+          turbo_confirm: _("Confirm to unpublish"),
+          confirm_details: unpublish_message(type, singular: false),
+          confirm_button: _("Unpublish #{type}s") }

--- a/app/views/backoffice/statuses/catalogues/create.turbo_stream.haml
+++ b/app/views/backoffice/statuses/catalogues/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+- @catalogues.each do |catalogue|
+  = turbo_stream.replace(catalogue, partial: "components/presentable/list_component/item_details",
+                                          locals: { obj: catalogue, klass: "catalogue" })
+= render_turbo_stream_flash

--- a/app/views/backoffice/statuses/providers/create.turbo_stream.haml
+++ b/app/views/backoffice/statuses/providers/create.turbo_stream.haml
@@ -1,0 +1,4 @@
+- @providers.each do |provider|
+  = turbo_stream.replace(provider, partial: "components/presentable/list_component/item_details",
+                                   locals: { obj: provider, klass: "provider" })
+= render_turbo_stream_flash

--- a/app/views/common_parts/_close_button.html.haml
+++ b/app/views/common_parts/_close_button.html.haml
@@ -1,0 +1,3 @@
+%button.close.close-link.pl-3.pr-3{ data: { action: "turbo-modal#hideModal" }, type: "button" }
+  %span
+    = _("Close")

--- a/app/views/common_parts/_project_browser.haml
+++ b/app/views/common_parts/_project_browser.haml
@@ -13,8 +13,8 @@
           "data-action" => "change->details-loader#changed",
           "data-details-loader-target" => "idSource"
         .input-group-append.ml-4
-          = link_to _("Add new project"), new_project_path, "data-turbo": true,
-            "data-e2e": "add-new-project-btn", "data-turbo-frame": "modal",
+          = link_to _("Add new project"), new_project_path, data: { turbo: true,
+            e2e: "add-new-project-btn", turbo_frame: "modal" },
             class: "btn btn-primary"
 
   %div{ "data-details-loader-target" => "details" }

--- a/app/views/components/presentable/list_component/_item_details.html.haml
+++ b/app/views/components/presentable/list_component/_item_details.html.haml
@@ -1,0 +1,24 @@
+= turbo_frame_tag obj do
+  .row
+    .col
+      - unless obj.deleted?
+        = check_box_tag "#{klass}_ids[]", obj.id,
+                          id: "#{klass}-#{obj.id}",
+                          class: "form-check-input",
+                          data: { list_target: "checkbox", action: "click->list#toggleActions click->list#checkIndetermination" }
+    .col
+      = link_to obj.name, polymorphic_path([:backoffice, obj],
+                  params: { page: params[:page] } || {}), class: "#{klass}-name",
+                  data: { turbo_frame: "_top" }
+    .col
+      = obj.created_at
+    .col.text-center
+      %span.status{ class: obj.status }
+        = obj.status
+    .col
+      - if policy([:backoffice, obj]).edit?
+        = link_to _("Edit"),
+                    polymorphic_path([:edit, :backoffice, obj]),
+                    data: { turbo_frame: "_top" },
+                    class: "edit-btn mr-4"
+        = render "components/presentable/list_component/item_menu", obj: obj

--- a/app/views/components/presentable/list_component/_item_menu.html.haml
+++ b/app/views/components/presentable/list_component/_item_menu.html.haml
@@ -1,0 +1,24 @@
+%a.kebab-link{ "aria-expanded": "false", "aria-haspopup": "true",
+          data: { toggle: "dropdown", target: "dropdown-#{obj.id}", list_target: "itemMenu" },
+          type: "button" }
+  %i.fa.fa-ellipsis-v
+  .dropdown-menu.dropdown-unroll.dropdown-menu-right{ id: "dropdown-#{obj.id}" }
+    - type = obj.class.name.downcase
+    - if policy([:backoffice, obj]).publish?
+      = link_to _("Publish"), polymorphic_path([:backoffice, obj, :publish]), class: "dropdown-item",
+            data: { turbo_method: :post, turbo_confirm: _("Confirm to publish"),
+            confirm_details: publish_message(type), confirm_button: _("Publish #{type}") }
+    - if policy([:backoffice, obj]).suspend?
+      = link_to _("Suspend"), polymorphic_path([:backoffice, obj, :unpublish], suspend: true),
+            class: "dropdown-item", data: { turbo_method: :post, turbo_confirm: _("Confirm to suspend"),
+            confirm_details: suspend_message(type), confirm_button: _("Suspend #{type}") }
+    - if policy([:backoffice, obj]).unpublish?
+      = link_to _("Unpublish"), polymorphic_path([:backoffice, obj, :unpublish]),
+            class: "dropdown-item", data: { turbo_method: :post, turbo_confirm: _("Confirm to unpublish"),
+            confirm_details: unpublish_message(type), confirm_button: _("Unpublish #{type}") }
+    - if policy([:backoffice, obj]).destroy?
+      .dropdown-divider
+      = link_to _("Delete"), polymorphic_path([:backoffice, obj]), class: "dropdown-item",
+            data: { e2e: "delete-menu", turbo_method: :delete,
+            turbo_confirm: _("This action cannot be undone"),
+            confirm_details: delete_message(type), confirm_button: _("Delete #{type}") }

--- a/app/views/components/presentable/list_component/_list_header.html.haml
+++ b/app/views/components/presentable/list_component/_list_header.html.haml
@@ -1,0 +1,12 @@
+%li.list-group-item.heading-row.providers
+  .row
+    .col= check_box_tag "#{klass}_ids[]", nil,
+                      id: "#{klass}",
+                      class: "form-check-input",
+                      data: { action: "click->list#toggleAll click->list#toggleActions", list_target: "checkAll" }
+    .col Name
+    .col Creation date
+    .col.text-center Status
+    .col
+      .d-none.selected-menu{ data: { list_target: "selectedMenu" } }
+        = render "components/presentable/list_component/selected_menu", type: klass, f: form

--- a/app/views/components/presentable/list_component/_list_item.html.haml
+++ b/app/views/components/presentable/list_component/_list_item.html.haml
@@ -1,0 +1,2 @@
+%li.list-group-item.providers
+  = render "components/presentable/list_component/item_details", obj: obj, klass: klass

--- a/app/views/components/presentable/list_component/_selected_menu.html.haml
+++ b/app/views/components/presentable/list_component/_selected_menu.html.haml
@@ -1,0 +1,15 @@
+%a.kebab-link{ "aria-expanded": "false", "aria-haspopup": "true",
+          data: { toggle: "dropdown", target: "selectedMenu" }, type: "button" }
+  %span Manage selected
+  %i.fa.fa-ellipsis-v.ml-1
+  .dropdown-menu.dropdown-unroll.dropdown-menu-right{ id: "dropdown-all" }
+    - if policy([:backoffice, :application]).management_role?
+      = link_to _("Publish selected"), "javascript:void(0);",
+        class: "dropdown-item",
+        onclick: "document.getElementById('publish-btn').click();"
+      = link_to _("Suspend selected"), "javascript:void(0);",
+        class: "dropdown-item",
+        onclick: "document.getElementById('suspend-btn').click();"
+      = link_to _("Unpublish selected"), "javascript:void(0);",
+        class: "dropdown-item",
+        onclick: "document.getElementById('unpublish-btn').click();"

--- a/app/views/layouts/_confirm_modal.html.haml
+++ b/app/views/layouts/_confirm_modal.html.haml
@@ -1,0 +1,15 @@
+%dialog#confirm.confirm-modal
+  .row
+    .col-12.col-md-11
+    .col-12.col-md-1
+      %button.close.modal__backdrop.confirm-cancel.float-right{ type: "button" }
+        %span{ aria: { hidden: "true" } } &times;
+  .row
+    .col-12
+      .modal__content
+        %h3#confirm-title.confirm-title Are you sure?
+        #confirm-body.confirm-body
+      .modal-actions
+        %button#dismiss-btn.btn.btn-secondary.close.modal__backdrop.confirm-cancel{ type: "button" }
+          Cancel
+        %button#confirm-accept.btn.btn-primary{ "data-e2e": "confirm-accept" } Yes, I'm Sure

--- a/app/views/layouts/_sections.html.haml
+++ b/app/views/layouts/_sections.html.haml
@@ -43,4 +43,4 @@
               data: { turbo_method: :delete, e2e: "logout" }
           - else
             %li
-              %strong= link_to _("Login"), user_checkin_omniauth_authorize_path, data_e2e: "login-btn"
+              %strong= link_to _("Login"), user_checkin_omniauth_authorize_path, "data-e2e": "login-btn"

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -6,6 +6,7 @@
       = render "layouts/badge" if ENV["MP_INSTANCE"]
       = render "layouts/admin/navbar"
       = render partial: "layouts/flash"
+      = render "layouts/confirm_modal"
     %main
 
       .container.backoffice

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,7 @@
       = render "layouts/flash"
     = render "layouts/welcome_modal"
     = turbo_frame_tag "modal"
+    = render "layouts/confirm_modal"
     %header
       = render "layouts/navbar",
         categories: @siblings || @root_categories,

--- a/app/views/layouts/backoffice.html.haml
+++ b/app/views/layouts/backoffice.html.haml
@@ -9,6 +9,7 @@
       #flash-messages.flash
         = render "layouts/flash"
       = turbo_frame_tag "modal"
+      = render "layouts/confirm_modal"
       = render "layouts/backoffice/navbar"
     %main
       .container

--- a/app/views/layouts/backoffice/_navbar.html.haml
+++ b/app/views/layouts/backoffice/_navbar.html.haml
@@ -21,10 +21,10 @@
             = link_to _("Services"), backoffice_services_path, class: "nav-link", data: { e2e: "owned-services" }
           - if policy([:backoffice, Provider]).index?
             = nav_link controller: :providers, html_options: { class: "nav-item" } do
-              = link_to _("Providers"), backoffice_providers_path, class: "nav-link", data: { e2e: "providers" }
+              = link_to _("Providers"), backoffice_providers_path(page: nil), class: "nav-link", data: { e2e: "providers" }
           - if policy([:backoffice, Catalogue]).index?
             = nav_link controller: :catalogues, html_options: { class: "nav-item" } do
-              = link_to _("Catalogues"), backoffice_catalogues_path, class: "nav-link", data: { e2e: "catalogues" }
+              = link_to _("Catalogues"), backoffice_catalogues_path(page: nil), class: "nav-link", data: { e2e: "catalogues" }
           = nav_link controller: :statistics, html_options: { class: "nav-item" } do
             = link_to _("Statistics"), backoffice_statistics_path, class: "nav-link", data: { e2e: "statistics" }
           - if current_user&.service_portfolio_manager?

--- a/app/views/layouts/clear.html.haml
+++ b/app/views/layouts/clear.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html{ lang: "en", class: "#{Rails.env}" }
   = content_for(:custom_scripts) do
-    %script{ src: "https://eosc-helpdesk.eosc-portal.eu/assets/form/form.js", id: "zammad_form_script" }
+    %script{ src: "https://helpdesk.sandbox.eosc-beyond.eu/assets/form/form.js", id: "zammad_form_script" }
   = render "layouts/head"
   .spinner-background
     .spinner
@@ -14,6 +14,7 @@
     #flash-messages.flash
       = render "layouts/flash"
     = turbo_frame_tag "modal"
+    = render "layouts/confirm_modal"
     %header
       = render "layouts/sections"
     %main

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -26,3 +26,4 @@
   - content_for(:buttons) do
     = f.button :submit, _("Create new project"), id: "form-modal-action-btn",
     class: "btn btn-primary pl-5 pr-5 float-left", type: "submit", form: "modal-form"
+    = render "common_parts/close_button"

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -12,8 +12,8 @@
     %hr.bottom-hr.mt-5.mb-4
     .row
       .col-12
-        %button.btn.btn-primary.pl-5.pr-5{ type: "submit",
-                                 form: "modal-form", "data-e2e": "create-project-btn", "data-turbo": false }
+        %button.btn.btn-primary.pl-5.pr-5{ type: "submit", form: "modal-form",
+                                           data: { e2e: "create-project-btn", turbo: false } }
           = _("Create new project")
         = back_link_to _("Cancel"), @project,
           class: "btn btn-link text-uppercase"

--- a/app/views/providers/questions/_form.html.haml
+++ b/app/views/providers/questions/_form.html.haml
@@ -19,3 +19,4 @@
   - content_for(:buttons) do
     = f.button :submit, _("SEND"), id: "form-modal-action-btn",
     class: "btn btn-primary pl-5 pr-5 float-left", type: "submit", form: "modal-form"
+    = render "common_parts/close_button"

--- a/app/views/services/questions/_form.html.haml
+++ b/app/views/services/questions/_form.html.haml
@@ -20,3 +20,4 @@
   - content_for(:buttons) do
     = f.button :submit, _("SEND"), id: "form-modal-action-btn",
     class: "btn btn-primary pl-5 pr-5 float-left", type: "submit", form: "modal-form"
+    = render "common_parts/close_button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,10 @@ Rails.application.routes.draw do
 
   resource :backoffice, only: :show
   namespace :backoffice do
+    namespace :statuses do
+      resources :providers, only: %i[create]
+      resources :catalogues, only: %i[create]
+    end
     resources :services, controller: "services", constraints: { id: %r{[^/]+} } do
       scope module: :services do
         resource :logo_preview, only: :show

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@rails/actiontext": "^7.1.3",
     "@rails/activestorage": "^7.1.3",
     "@rails/ujs": "^7.1.3",
+    "@rolemodel/turbo-confirm": "^2.0.2",
     "bootstrap": "^4.1.1",
     "bootstrap-datepicker": "^1.8.0",
     "choices.js": "^10.0.0",

--- a/spec/features/admin/help_builder_spec.rb
+++ b/spec/features/admin/help_builder_spec.rb
@@ -38,7 +38,8 @@ RSpec.feature "Marketplace help builder", manager_frontend: true do
 
       visit admin_help_path
 
-      accept_confirm { find(".delete-icon").click }
+      find(".delete-icon").click
+      find("#confirm-accept").click
 
       expect(page).to have_current_path(admin_help_path)
       expect(page).to_not have_content(section.title)
@@ -81,7 +82,8 @@ RSpec.feature "Marketplace help builder", manager_frontend: true do
 
       visit admin_help_path
 
-      accept_confirm { find("#delete-lead-#{section.id}").click }
+      find("#delete-lead-#{section.id}").click
+      find("#confirm-accept").click
 
       expect(page).to have_current_path(admin_help_path)
       expect(page).to_not have_content(item.title)

--- a/spec/features/admin/lead_builder_spec.rb
+++ b/spec/features/admin/lead_builder_spec.rb
@@ -40,7 +40,8 @@ RSpec.feature "Marketplace lead builder", manager_frontend: true do
 
       visit admin_leads_path
 
-      accept_confirm { find("#delete-lead-section-#{section.id}").click }
+      find("#delete-lead-section-#{section.id}").click
+      find("#confirm-accept").click
 
       expect(page).to have_current_path(admin_leads_path)
       expect(page).to_not have_content(section.title)
@@ -86,7 +87,8 @@ RSpec.feature "Marketplace lead builder", manager_frontend: true do
 
       visit admin_leads_path
 
-      accept_confirm { find("#delete-lead-#{item.id}").click }
+      find("#delete-lead-#{item.id}").click
+      find("#confirm-accept").click
 
       expect(page).to have_current_path(admin_leads_path)
       expect(page).to_not have_content(item.header)

--- a/test/system/cypress.config.ts
+++ b/test/system/cypress.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   defaultCommandTimeout: 20000,
-  pageLoadTimeout: 100000,
-  responseTimeout: 100000,
+  pageLoadTimeout: 50000,
+  responseTimeout: 50000,
   viewportWidth: 1400,
   viewportHeight: 1200,
   fileServerFolder: "./",

--- a/test/system/cypress/e2e/regression_tests/backoffice/categories/categories.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/categories/categories.spec.ts
@@ -15,7 +15,7 @@ describe("Category", () => {
     cy.loginAs(user);
   });
 
-  it("should create new category without parent", () => {
+  it("should create new categories without parent", () => {
     cy.openUserDropdown();
     cy.get("[data-e2e='backoffice']").click();
     cy.location("href").should("contain", "/backoffice");
@@ -29,7 +29,7 @@ describe("Category", () => {
     cy.contains("div.alert-success", message.successCreationMessage);
   });
 
-  it("should create new category with parent", () => {
+  it("should create new categories with parent", () => {
     cy.visit("/backoffice/other_settings/categories/new");
     cy.fillFormCreateCategory({ ...category1, parent: "Sharing & Discovery" }, correctLogo);
     cy.get("[data-e2e='create-category-btn']").click();
@@ -46,14 +46,14 @@ describe("Category", () => {
       });
   });
 
-  it("should add new category without logo", () => {
+  it("should add new categories without logo", () => {
     cy.visit("/backoffice/other_settings/categories/new");
     cy.fillFormCreateCategory(category2, false);
     cy.get("[data-e2e='create-category-btn']").click();
     cy.contains("div.alert-success", message.successCreationMessage);
   });
 
-  it("shouldn't create new category", () => {
+  it("shouldn't create new categories", () => {
     cy.visit("/backoffice/other_settings/categories/new");
     cy.fillFormCreateCategory({ ...category3, name: "" }, wrongLogo);
     cy.get("[data-e2e='create-category-btn']").click();
@@ -61,19 +61,21 @@ describe("Category", () => {
     cy.contains("div.invalid-feedback", message.alertNameValidation).should("be.visible");
   });
 
-  it("shouldn't delete category with successors connected to it", () => {
+  it("shouldn't delete categories with successors connected to it", () => {
     cy.visit("/backoffice/other_settings/categories");
     cy.get("[data-e2e='backoffice-categories-list'] li").eq(0).find("a.delete-icon").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains(".alert-danger", message.alertDeletionMessageSuccessors).should("be.visible");
   });
 
-  it("shouldn't delete category with services connected to it", () => {
+  it("shouldn't delete categories with services connected to it", () => {
     cy.visit("/backoffice/other_settings/categories");
     cy.get("[data-e2e='backoffice-categories-list'] li").eq(2).find("a.delete-icon").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains(".alert-danger", message.alertDeletionMessageResource).should("be.visible");
   });
 
-  it("should delete category without services", () => {
+  it("should delete categories without services", () => {
     cy.visit("/backoffice/other_settings/categories/new");
     cy.fillFormCreateCategory(category4, correctLogo);
     cy.get("[data-e2e='create-category-btn']").click();
@@ -83,16 +85,17 @@ describe("Category", () => {
       .then((value) => {
         cy.visit("/backoffice/other_settings/categories");
         cy.contains(value).parent().find("a.delete-icon").click();
+        cy.get("[data-e2e='confirm-accept']").click();
         cy.contains(".alert-success", message.successDeletionMessage).should("be.visible");
       });
   });
 
-  it("should edit category", () => {
+  it("should edit categories", () => {
     cy.visit("/backoffice/other_settings/categories");
     cy.get("[data-e2e='backoffice-categories-list'] li").eq(0).find("a").contains("Edit").click();
-    cy.fillFormCreateCategory({ description: "Edited category" }, false);
+    cy.fillFormCreateCategory({ description: "Edited categories" }, false);
     cy.get("[data-e2e='create-category-btn']").click();
     cy.contains(".alert-success", message.successUpdationMessage);
-    cy.contains("p", "Edited category").should("be.visible");
+    cy.contains("p", "Edited categories").should("be.visible");
   });
 });

--- a/test/system/cypress/e2e/regression_tests/backoffice/platforms/platforms.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/platforms/platforms.spec.ts
@@ -53,6 +53,7 @@ describe("Platform", () => {
   it("should delete platform", () => {
     cy.visit("/backoffice/other_settings/platforms");
     cy.get("[data-e2e='backoffice-platforms-list'] li").eq(0).find("a.delete-icon").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 });

--- a/test/system/cypress/e2e/regression_tests/backoffice/providers/providers.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/providers/providers.spec.ts
@@ -29,7 +29,7 @@ describe("Providers", () => {
     cy.location("href").should("contain", "/backoffice");
     cy.get("[data-e2e='providers']").click();
     cy.location("href").should("contain", "/backoffice/providers");
-    cy.get("[data-e2e='backoffice-providers-list'] a").eq(0).click();
+    cy.get("[data-e2e='backoffice-providers-list'] a.provider-name").eq(0).click();
     cy.contains("a", "Edit").should("be.visible");
     cy.contains("a", "Delete").should("be.visible");
   });
@@ -109,31 +109,41 @@ describe("Providers", () => {
 
   it("should delete provider with services with deleted status", () => {
     cy.visit("/backoffice/providers");
-    cy.contains("a", providerWithResourceDeleted).parents("li.providers").find("a.delete-icon").click();
+    cy.contains("a", providerWithResourceDeleted).parents("li.providers").find("a.kebab-link svg").click();
+    cy.get(".dropdown-menu.show").find("[data-e2e='delete-menu']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 
   it("should delete provider with services with draft status", () => {
     cy.visit("/backoffice/providers");
-    cy.contains("a", providerWithResourceDraft).parents("li.providers").find("a.delete-icon").click();
+    cy.contains("a", providerWithResourceDraft).parents("li.providers").find("a.kebab-link svg").click();
+    cy.get(".dropdown-menu.show").find("[data-e2e='delete-menu']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 
   it("should delete provider with services with published status", () => {
     cy.visit("/backoffice/providers");
-    cy.contains("a", providerWithResourcePublished).parents("li.providers").find("a.delete-icon").click();
+    cy.contains("a", providerWithResourcePublished).parents("li.providers").find("a.kebab-link svg").click();
+    cy.get(".dropdown-menu.show").find("[data-e2e='delete-menu']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 
   it("should delete provider with services with errored status", () => {
     cy.visit("/backoffice/providers");
-    cy.contains("a", providerWithResourceErrored).parents("li.providers").find("a.delete-icon").click();
+    cy.contains("a", providerWithResourceErrored).parents("li.providers").find("a.kebab-link svg").click();
+    cy.get(".dropdown-menu.show").find("[data-e2e='delete-menu']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 
   it("should delete provider which is services provider for published resources", () => {
     cy.visit("/backoffice/providers");
-    cy.contains("a", resourceProviderForPublishedResource).parents("li.providers").find("a.delete-icon").click();
+    cy.contains("a", resourceProviderForPublishedResource).parents("li.providers").find("a.kebab-link svg").click();
+    cy.get(".dropdown-menu.show").find("[data-e2e='delete-menu']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("div.alert-success", message.successDeletionMessage).should("be.visible");
   });
 

--- a/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
@@ -42,6 +42,7 @@ describe("Owned services", () => {
     cy.contains("a", "Set parameters and offers").should("be.visible");
     cy.contains("span", "unpublished").should("be.visible");
     cy.get("[data-e2e='publish-btn']").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains("span", "published").should("be.visible");
     cy.get(".service-details-header h2")
       .invoke("text")

--- a/test/system/cypress/e2e/regression_tests/backoffice/scientific-domain/scientific-domain.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/scientific-domain/scientific-domain.spec.ts
@@ -86,6 +86,7 @@ describe("Scientific Domain", () => {
   it("shouldn't delete scientific domain with successors connected to it", () => {
     cy.visit("/backoffice/other_settings/scientific_domains");
     cy.get("[data-e2e='backoffice-scientific-domains-list'] li").eq(0).find("a.delete-icon").click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains(".alert-danger", message.alertDeletionMessageSuccessors).should("be.visible");
   });
 
@@ -96,6 +97,7 @@ describe("Scientific Domain", () => {
       .parent()
       .find("a.delete-icon")
       .click();
+    cy.get("[data-e2e='confirm-accept']").click();
     cy.contains(".alert-danger", message.alertDeletionMessageResource).should("be.visible");
   });
 
@@ -109,6 +111,7 @@ describe("Scientific Domain", () => {
       .then((value) => {
         cy.visit("/backoffice/other_settings/scientific_domains");
         cy.contains(value).parent().find("a.delete-icon").click();
+        cy.get("[data-e2e='confirm-accept']").click();
         cy.contains(".alert-success", message.successDeletionMessage).should("be.visible");
       });
   });

--- a/test/system/cypress/e2e/regression_tests/backoffice/vocabularies/vocabularies.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/vocabularies/vocabularies.spec.ts
@@ -59,12 +59,14 @@ describe("Vocabularies", () => {
   it("shouldn't delete vocabulary with successors connected to it", () => {
     cy.visit("/backoffice/other_settings/vocabularies");
     cy.get("[data-e2e='backoffice-vocabulary-list'] li").contains("Businesses").parent().find("a.delete-icon").click();
+    cy.get("#confirm-accept").click();
     cy.contains(".alert-danger", message.alertDeletionMessageSuccessors).should("be.visible");
   });
 
   it("shouldn't delete scientific domain with services connected to it", () => {
     cy.visit("/backoffice/other_settings/vocabularies");
     cy.get("[data-e2e='backoffice-vocabulary-list'] li").contains("Providers").parent().find("a.delete-icon").click();
+    cy.get("#confirm-accept").click();
     cy.contains(".alert-danger", message.alertDeletionMessageResource).should("be.visible");
   });
 
@@ -79,6 +81,7 @@ describe("Vocabularies", () => {
       .then((value) => {
         cy.visit("/backoffice/other_settings/vocabularies");
         cy.contains(value).parent().find("a.delete-icon").click();
+        cy.get("#confirm-accept").click();
         cy.contains(".alert-success", message.successDeletionMessage).should("be.visible");
       });
   });

--- a/test/system/cypress/e2e/regression_tests/home-page/scientific-domain_categories.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/home-page/scientific-domain_categories.spec.ts
@@ -8,7 +8,7 @@ describe("Scientific domain", () => {
     cy.get("a[data-e2e='branch-link']").eq(0).click();
     cy.location("href").should("include", "search/service");
   });
-  it.skip("should go to services page with selected category", () => {
+  it.skip("should go to services page with selected categories", () => {
     cy.intercept("GET", "/categories/*").as("categories");
     cy.get("li").contains("Categories").click();
     cy.get("a[href*='categories'][data-e2e='branch-link']").eq(0).click();

--- a/test/system/cypress/e2e/regression_tests/service-page/my_eosc_marketplace/my-project.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/service-page/my_eosc_marketplace/my-project.spec.ts
@@ -68,6 +68,7 @@ describe("My project", () => {
     cy.fillFormProject(project3);
     cy.get("[data-e2e='create-project-btn']").click();
     cy.contains("a", "Delete").click();
+    cy.get("[id='confirm-accept").click();
     cy.contains(".alert-success", "Project removed successfully").should("be.visible");
   });
 });

--- a/test/system/package.json
+++ b/test/system/package.json
@@ -14,17 +14,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cypress": "13.8.1",
-    "typescript": "^5.4.5"
+    "cypress": "14.0.0",
+    "typescript": "^5.7.3"
   },
   "devDependencies": {
-    "@cypress/grep": "^4.0.1",
-    "@medv/finder": "^3.2.0",
+    "@cypress/grep": "^4.1.0",
+    "@medv/finder": "^4.0.2",
     "@types/node": "^20.12.7",
-    "cypress-fail-fast": "^7.1.0",
+    "cypress-fail-fast": "^7.1.1",
     "cypress-file-upload": "^5.0.8",
     "cypress-promise": "^1.1.0",
-    "cypress-terminal-report": "^6.0.1",
-    "cypress-wait-until": "^3.0.1"
+    "cypress-terminal-report": "^7.1.0",
+    "cypress-wait-until": "^3.0.2"
   }
 }

--- a/test/system/yarn.lock
+++ b/test/system/yarn.lock
@@ -2,50 +2,49 @@
 # yarn lockfile v1
 
 
-"@babel/helper-plugin-utils@^7.24.7":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz#94ee67e8ec0e5d44ea7baeb51e571bd26af07878"
-  integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
+"@babel/helper-plugin-utils@^7.25.9":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
+  integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
 
-"@babel/helper-string-parser@^7.24.8":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz#5b3329c9a58803d5df425e5785865881a81ca48d"
-  integrity sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
-"@babel/helper-validator-identifier@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
-  integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/parser@^7.24.7":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.6.tgz#85660c5ef388cbbf6e3d2a694ee97a38f18afe2f"
-  integrity sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.5.tgz#6fec9aebddef25ca57a935c86dbb915ae2da3e1f"
+  integrity sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==
   dependencies:
-    "@babel/types" "^7.25.6"
+    "@babel/types" "^7.26.5"
 
 "@babel/plugin-syntax-jsx@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
-  integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz#a34313a178ea56f1951599b929c1ceacee719290"
+  integrity sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.24.7"
+    "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/types@^7.25.6":
-  version "7.25.6"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.6.tgz#893942ddb858f32ae7a004ec9d3a76b3463ef8e6"
-  integrity sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==
+"@babel/types@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.5.tgz#7a1e1c01d28e26d1fe7f8ec9567b3b92b9d07747"
+  integrity sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==
   dependencies:
-    "@babel/helper-string-parser" "^7.24.8"
-    "@babel/helper-validator-identifier" "^7.24.7"
-    to-fast-properties "^2.0.0"
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cypress/grep@^4.0.1":
+"@cypress/grep@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@cypress/grep/-/grep-4.1.0.tgz#77dba973f0023ce01f5d2481a257f3e55c8f73ee"
   integrity sha512-yUscMiUgM28VDPrNxL19/BhgHZOVrAPrzVsuEcy6mqPqDYt8H8fIaHeeGQPW4CbMu/ry9sehjH561WDDBIXOIg==
@@ -54,10 +53,10 @@
     find-test-names "^1.28.18"
     globby "^11.0.4"
 
-"@cypress/request@^3.0.0":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.5.tgz#d893a6e68ce2636c085fcd8d7283c3186499ba63"
-  integrity sha512-v+XHd9XmWbufxF1/bTaVm2yhbxY+TB4YtWRqF2zaXBlDNMkls34KiATz0AVDLavL3iB6bQk9/7n3oY1EoLSWGA==
+"@cypress/request@^3.0.6":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.7.tgz#6a74a4da98d9e5ae9121d6e2d9c14780c9b5cf1a"
+  integrity sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -72,9 +71,9 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "6.13.0"
+    qs "6.13.1"
     safe-buffer "^5.1.2"
-    tough-cookie "^4.1.3"
+    tough-cookie "^5.0.0"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -86,10 +85,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@medv/finder@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-3.2.0.tgz#dffeb5b04d754ca4e575bbbee89b24935277908e"
-  integrity sha512-JmU7JIBwyL8RAzefvzALT4sP2M0biGk8i2invAgpQmma/QgfsaqoHIvJ7S0YC8n9hUVG8X3Leul2nGa06PvhbQ==
+"@medv/finder@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@medv/finder/-/finder-4.0.2.tgz#670e8a93e48ce847ee877819ee9f90387624a14e"
+  integrity sha512-RraNY9SCcx4KZV0Dh6BEW6XEW2swkqYca74pkFFRw6hHItSHiy+O/xMnpbofjYbzXj0tSpBGthUF1hHTsr3vIQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -113,16 +112,16 @@
     fastq "^1.6.0"
 
 "@types/node@*":
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
-  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
+  version "22.10.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.10.tgz#85fe89f8bf459dc57dfef1689bd5b52ad1af07e6"
+  integrity sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.20.0"
 
 "@types/node@^20.12.7":
-  version "20.16.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.5.tgz#d43c7f973b32ffdf9aa7bd4f80e1072310fd7a53"
-  integrity sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==
+  version "20.17.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.17.16.tgz#b33b0edc1bf925b27349e494b871ca4451fabab4"
+  integrity sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==
   dependencies:
     undici-types "~6.19.2"
 
@@ -132,9 +131,9 @@
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
 "@types/sizzle@^2.3.2":
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.8.tgz#518609aefb797da19bf222feb199e8f653ff7627"
-  integrity sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.9.tgz#d4597dbd4618264c414d7429363e3f50acb66ea2"
+  integrity sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==
 
 "@types/yauzl@^2.9.1":
   version "2.10.3"
@@ -151,9 +150,9 @@ acorn-walk@^8.2.0:
     acorn "^8.11.0"
 
 acorn@^8.11.0:
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
-  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -286,16 +285,21 @@ cachedir@^2.3.0:
   resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
   integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
 
-call-bind@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
-  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
+call-bind-apply-helpers@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz#32e5892e6361b29b0b545ba6f7763378daca2840"
+  integrity sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==
   dependencies:
-    es-define-property "^1.0.0"
     es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    set-function-length "^1.2.1"
+
+call-bound@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.3.tgz#41cfd032b593e39176a71533ab4f384aa04fd681"
+  integrity sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    get-intrinsic "^1.2.6"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -315,10 +319,10 @@ check-more-types@^2.24.0:
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
 
-ci-info@^3.2.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
-  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+ci-info@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.1.0.tgz#92319d2fa29d2620180ea5afed31f589bc98cf83"
+  integrity sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -383,21 +387,26 @@ common-tags@^1.8.0:
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
 cross-spawn@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress-fail-fast@^7.1.0:
+cypress-fail-fast@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/cypress-fail-fast/-/cypress-fail-fast-7.1.1.tgz#4be6ddbed8c284358faf488c73b6bd87f69cda49"
   integrity sha512-9qPXikVY20OWdc97DO2++0AS4IF9kB+vuPhP8/0wXchcnFIsiCiwvQhOEBSdVHr1mZi87h0Z8jYEB4VLPzNkGg==
@@ -414,28 +423,28 @@ cypress-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/cypress-promise/-/cypress-promise-1.1.0.tgz#f2d66965945fe198431aaf692d5157cea9d47b25"
   integrity sha512-DhIf5PJ/a0iY+Yii6n7Rbwq+9TJxU4pupXYzf9mZd8nPG0AzQrj9i+pqINv4xbI2EV1p+PKW3maCkR7oPG4GrA==
 
-cypress-terminal-report@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-6.2.0.tgz#9456c4003ade23a0908746edf9f926846ee6b1bc"
-  integrity sha512-u5YaGaVhRW7uATZRx0Ccg2QIfwP08cNpihQEbtvN0toT/oZbQYHo9oNkrkX6hPJ5kf3DSDj194G61greu4gG0g==
+cypress-terminal-report@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cypress-terminal-report/-/cypress-terminal-report-7.1.0.tgz#77f2f0f4380eaba43f8c88914defd8f638708988"
+  integrity sha512-CBXxY19HNX2VFcZ0uifomzs0kuYKCTb2pPgJmluiHI5XHvvbHPFufHAAacM8z/pSOtHoovo/WU+fxE5KcZ8C4Q==
   dependencies:
     chalk "^4.0.0"
+    compare-versions "^6.1.1"
     fs-extra "^10.1.0"
     process "^0.11.10"
-    semver "^7.5.4"
-    tv4 "^1.3.0"
+    superstruct "0.14.2"
 
-cypress-wait-until@^3.0.1:
+cypress-wait-until@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-3.0.2.tgz#c90dddfa4c46a2c422f5b91d486531c560bae46e"
   integrity sha512-iemies796dD5CgjG5kV0MnpEmKSH+s7O83ZoJLVzuVbZmm4lheMsZqAVT73hlMx4QlkwhxbyUzhOBUOZwoOe0w==
 
-cypress@13.8.1:
-  version "13.8.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.8.1.tgz#f558e51b770a409e2360031bbd36c3f4fb3f2db4"
-  integrity sha512-Uk6ovhRbTg6FmXjeZW/TkbRM07KPtvM5gah1BIMp4Y2s+i/NMxgaLw0+PbYTOdw1+egE0FP3mWRiGcRkjjmhzA==
+cypress@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.0.0.tgz#a71cb0a243a0bfeb97b6973ab9c5291ca5288e93"
+  integrity sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==
   dependencies:
-    "@cypress/request" "^3.0.0"
+    "@cypress/request" "^3.0.6"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
@@ -446,6 +455,7 @@ cypress@13.8.1:
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
+    ci-info "^4.0.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
     commander "^6.2.1"
@@ -460,7 +470,6 @@ cypress@13.8.1:
     figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
-    is-ci "^3.0.1"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
     listr2 "^3.8.3"
@@ -474,7 +483,8 @@ cypress@13.8.1:
     request-progress "^3.0.0"
     semver "^7.5.3"
     supports-color "^8.1.1"
-    tmp "~0.2.1"
+    tmp "~0.2.3"
+    tree-kill "1.2.2"
     untildify "^4.0.0"
     yauzl "^2.10.0"
 
@@ -498,20 +508,11 @@ debug@^3.1.0:
     ms "^2.1.1"
 
 debug@^4.1.1, debug@^4.3.3, debug@^4.3.4:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
-  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
-
-define-data-property@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
-  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
-  dependencies:
-    es-define-property "^1.0.0"
-    es-errors "^1.3.0"
-    gopd "^1.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -524,6 +525,15 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -553,17 +563,22 @@ enquirer@^2.3.6:
     ansi-colors "^4.1.1"
     strip-ansi "^6.0.1"
 
-es-define-property@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
-  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
-  dependencies:
-    get-intrinsic "^1.2.4"
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
 
 es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -624,20 +639,20 @@ extsprintf@^1.2.0:
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fast-glob@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
-    micromatch "^4.0.4"
+    micromatch "^4.0.8"
 
 fastq@^1.6.0:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
-  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.18.0.tgz#d631d7e25faffea81887fe5ea8c9010e1b36fee0"
+  integrity sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==
   dependencies:
     reusify "^1.0.4"
 
@@ -663,9 +678,9 @@ fill-range@^7.1.1:
     to-regex-range "^5.0.1"
 
 find-test-names@^1.28.18:
-  version "1.28.30"
-  resolved "https://registry.yarnpkg.com/find-test-names/-/find-test-names-1.28.30.tgz#a7cc8c8c89b0d23f041179cfbf8c41bcbc3353b8"
-  integrity sha512-b5PLJ5WnskdaYHBf+38FN/4TKh5lqwrltITkqxuARsN2bW6civrhqOXbVA+4727YNowYLt/jtIC9Dsn7eJSP6A==
+  version "1.29.2"
+  resolved "https://registry.yarnpkg.com/find-test-names/-/find-test-names-1.29.2.tgz#d6a50aaada84fdfe7877506f88d1d1131834f8b9"
+  integrity sha512-C+MYRocRaHXePUg/dwvuwkJ329kwf+dd4Hbun9IoaW/WSSGlQYBwFhuphm5CAjRtpFelYbT8dc3F1aN4KXiXaw==
   dependencies:
     "@babel/parser" "^7.24.7"
     "@babel/plugin-syntax-jsx" "^7.24.7"
@@ -680,9 +695,9 @@ forever-agent@~0.6.1:
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
 form-data@~4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.1.tgz#ba1076daaaa5bfd7e99c1a6cb02aa0a5cff90d48"
+  integrity sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -712,16 +727,29 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
-  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.7.tgz#dcfcb33d3272e15f445d15124bc0a216189b9044"
+  integrity sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==
   dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-define-property "^1.0.1"
     es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
     function-bind "^1.1.2"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
-    hasown "^2.0.0"
+    get-proto "^1.0.0"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
@@ -770,12 +798,10 @@ globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.11"
@@ -787,24 +813,12 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-property-descriptors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
-  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
-  dependencies:
-    es-define-property "^1.0.0"
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
-has-proto@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.3.tgz#b31ddfe9b0e6e9914536a6ab286426d0214f77fd"
-  integrity sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==
-
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-hasown@^2.0.0:
+hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -844,13 +858,6 @@ ini@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
-
-is-ci@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
-  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
-  dependencies:
-    ci-info "^3.2.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -993,6 +1000,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -1003,7 +1015,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4:
+micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -1045,10 +1057,10 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-object-inspect@^1.13.1:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
-  integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
+object-inspect@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
+  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
 
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1121,11 +1133,6 @@ proxy-from-env@1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
-psl@^1.1.33:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
-
 pump@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.2.tgz#836f3edd6bc2ee599256c924ffe0d88573ddcbf8"
@@ -1134,22 +1141,12 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
-  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-qs@6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
-  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+qs@6.13.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.1.tgz#3ce5fc72bd3a8171b85c99b93c65dd20b7d1b16e"
+  integrity sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==
   dependencies:
     side-channel "^1.0.6"
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -1162,11 +1159,6 @@ request-progress@^3.0.0:
   integrity sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==
   dependencies:
     throttleit "^1.0.0"
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -1210,22 +1202,10 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^7.5.3, semver@^7.5.4:
+semver@^7.5.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
-
-set-function-length@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
-  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
-  dependencies:
-    define-data-property "^1.1.4"
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.4"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.2"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -1239,15 +1219,45 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
-  integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
   dependencies:
-    call-bind "^1.0.7"
     es-errors "^1.3.0"
-    get-intrinsic "^1.2.4"
-    object-inspect "^1.13.1"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
+side-channel@^1.0.6:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
 
 signal-exit@^3.0.2:
   version "3.0.7"
@@ -1318,6 +1328,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+superstruct@0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
+  integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -1342,15 +1357,22 @@ through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tmp@~0.2.1:
+tldts-core@^6.1.74:
+  version "6.1.74"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.74.tgz#4c8628b3ceefaae9667316704376472592b3a463"
+  integrity sha512-gTwtY6L2GfuxiL4CWpLknv9JDYYqBvKCk/BT5uAaAvCA0s6pzX7lr2IrkQZSUlnSjRHIjTl8ZwKCVXJ7XNRWYw==
+
+tldts@^6.1.32:
+  version "6.1.74"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.74.tgz#ff7e55614c30795b07cc29a26be53693f167b31c"
+  integrity sha512-O5vTZ1UmmEmrLl/59U9igitnSMlprALLaLgbv//dEvjobPT9vyURhHXKMCDLEhn3qxZFIkb9PwAfNYV0Ol7RPQ==
+  dependencies:
+    tldts-core "^6.1.74"
+
+tmp@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
   integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1359,20 +1381,22 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
-  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+tough-cookie@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.0.tgz#0667b0f2fbb5901fe6f226c3e0b710a9a4292f87"
+  integrity sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==
   dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
+    tldts "^6.1.32"
+
+tree-kill@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 tslib@^2.1.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
-  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -1380,11 +1404,6 @@ tunnel-agent@^0.6.0:
   integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
   dependencies:
     safe-buffer "^5.0.1"
-
-tv4@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
-  integrity sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -1396,20 +1415,20 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^5.4.5:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+typescript@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-universalify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
-  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 universalify@^2.0.0:
   version "2.0.1"
@@ -1420,14 +1439,6 @@ untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
-
-url-parse@^1.5.3:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 uuid@^8.3.2:
   version "8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,11 @@
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.400.tgz#b2a76bdccb5197b9e866954536106386c87cfab5"
   integrity sha512-YwvXm3BR5tn+VCAKYGycLejMRVZE3Ionj5gFjEeGXCZnI0Rpi+7dKpmyu90kdUY7dRUFpHTdu9zZceEzFLl38w==
 
+"@rolemodel/turbo-confirm@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@rolemodel/turbo-confirm/-/turbo-confirm-2.0.2.tgz#bea18fcd79e91fe2d2c08d529113a26d4e1812f4"
+  integrity sha512-IoZw7Z1ChRT9Xt0u7C2mIltrpk6FV866aSiz8u+95tmACYmyyS0S16SHynAdEmwJyLTJr3HrOVuErftGDvFRNg==
+
 "@types/estree@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"


### PR DESCRIPTION
This PR adds new panel to change statuses of multiple objects.
Currently implemented in backoffice/providers and then in other objects (catalogues and services)

Closes #65 