### PR TITLE
style: [#124] provider and catalogue details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ Please view this file on the master branch, on stable branches it's out of date.
 ## [3.58.1] 2025-03-04
 
 ### Changed
+
 - Default link to the Explore service (@goreck888)
+- Provider and catalogue backoffice view (@jarekzet)
+- Dropdown menu mods (@jarekzet)
 
 
 ## [3.58.0] 2025-01-22

--- a/app/assets/stylesheets/_bootstrap-customizations.scss
+++ b/app/assets/stylesheets/_bootstrap-customizations.scss
@@ -3246,6 +3246,13 @@ label[data-multicheckbox].small {
   position: relative;
   flex-wrap: wrap;
 
+  &.provider,
+  &.catalogue {
+    display: flex;
+    flex-direction: column;
+    row-gap: 40px;
+  }
+
   &:hover {
     border: 1px solid $landing-01;
   }
@@ -6608,12 +6615,7 @@ abbr[title] {
 }
 
 .status-row {
-  background: $tag-bg-color;
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
-  border-radius: 2px;
-  padding: 8px 20px;
-  margin-bottom: 20px;
+  margin-left: auto;
 
   span {
     margin: 0;
@@ -9485,6 +9487,7 @@ footer {
       }
     }
   }
+
   // scss-lint:enable all
 
   .approval-requests {
@@ -9520,6 +9523,95 @@ footer {
         background: url("assets/icon-manage.svg") 0 50% no-repeat;
         background-size: 18px auto;
         font-size: 14px;
+      }
+    }
+  }
+
+  .title-row-wrapper {
+    display: flex;
+    margin-bottom: 35px;
+
+    h1 {
+      color: $custom-21;
+      font-size: 24px;
+      line-height: 34px;
+      font-weight: 400;
+      margin: 0;
+
+      span {
+        color: $palette-black;
+      }
+    }
+  }
+
+  .status-column {
+    .status {
+      margin: 0 0 0 12px;
+      text-align: center;
+      color: $custom-25;
+      font-size: 18px;
+      padding: 7px 14px;
+      font-weight: 600;
+      text-transform: capitalize;
+      border-radius: 8px;
+      line-height: 1.1;
+      background: $custom-26;
+    }
+  }
+
+  .actions-column {
+    margin-left: auto;
+    min-width: 390px;
+  }
+
+  .btn-special {
+    padding: 6px 26px;
+    border-radius: 8px;
+    border: 1px solid $custom-12;
+    color: $custom-12;
+    background: $alert-bg;
+    font-size: 14px;
+    font-weight: 400;
+
+    &:hover {
+      color: $palette-white;
+      background: $custom-12;
+      border-color: $custom-12;
+    }
+
+    &.no-border {
+      border: none;
+      background: none;
+
+      &:hover {
+        color: $custom-12;
+        background: $alert-bg;
+      }
+    }
+
+    &.delete-button {
+      line-height: 22px;
+
+      &::before {
+        font-family: "Font Awesome 6 Free";
+        content: "\f1f8";
+        display: inline-block;
+        font-size: 14px;
+        margin-right: 10px;
+        font-weight: 600;
+      }
+    }
+
+    &.edit-button {
+      line-height: 22px;
+
+      &::before {
+        font-family: "Font Awesome 6 Free";
+        content: "\f044";
+        display: inline-block;
+        font-size: 14px;
+        margin-right: 10px;
+        font-weight: 600;
       }
     }
   }

--- a/app/components/presentable/status_actions_component.html.haml
+++ b/app/components/presentable/status_actions_component.html.haml
@@ -1,15 +1,25 @@
-.status-row
-  .row
-    .col-12.col-lg-4
-      %span
-        = _("Status") + ":"
-      %span.font-weight-bold= @object.status
-    .col-12.col-lg-8.service-buttons
-      .btn-group.float-right
-        - if @publish
-          = link_to _("Publish"),
+.status-column
+  .status= @object.status
+.actions-column
+  .service-buttons
+    .btn-group.float-right
+      - if @destroy
+        = link_to _("Delete"),
+              send("backoffice_#{@object_type}_path", @object.id),
+              class: "btn-special no-border delete-button",
+              data: { turbo_confirm: action_prompt(@object_type, "remove"), turbo_method: :delete }
+
+      - if @unpublish
+        = link_to _("Unpublish"),
+              unpublish_path,
+              class: "btn-special ml-3",
+              data: { turbo_confirm: action_prompt(@object_type, "unpublish"),
+              turbo_method: :post }
+
+      - if @publish
+        = link_to _("Publish"),
               send("backoffice_#{@object_type}_publish_path", @object),
-              class: "btn btn-primary",
+              class: "btn btn-primary ml-3",
               data: { turbo_confirm: "Confirm to publish",
               confirm_details: "Are you sure you want to publish this #{@object_type}?",
               confirm_button: "Publish",
@@ -17,17 +27,6 @@
         - if @suspend
           = link_to _("Suspend"),
               suspend_path,
-              class: "btn btn-info",
+              class: "btn-special ml-3",
               data: { turbo_confirm: action_prompt(@object_type, "suspend"),
               turbo_method: :post }
-        - if @unpublish
-          = link_to _("Unpublish"),
-              unpublish_path,
-              class: "btn btn-error",
-              data: { turbo_confirm: action_prompt(@object_type, "unpublish"),
-              turbo_method: :post }
-        - if @destroy
-          = link_to _("Delete"),
-              send("backoffice_#{@object_type}_path", @object.id),
-              class: "btn btn-danger",
-              data: { turbo_confirm: action_prompt(@object_type, "remove"), turbo_method: :delete }

--- a/app/views/backoffice/catalogues/edit.html.haml
+++ b/app/views/backoffice/catalogues/edit.html.haml
@@ -2,8 +2,10 @@
 - breadcrumb :backoffice_catalogue_edit, @catalogue
 
 .container.p-0.backoffice
-  %h1= _("Edit #{@catalogue.name} Catalogue")
-  .container.p-0.backoffice
+  .title-row-wrapper
+    .title-column
+      %h1= _("Edit #{@catalogue.name} Catalogue")
+
     = render Presentable::StatusActionsComponent.new(object: @catalogue,
       publish: policy([:backoffice, @catalogue]).publish?,
       suspend: policy([:backoffice, @catalogue]).suspend?,

--- a/app/views/backoffice/catalogues/show.html.haml
+++ b/app/views/backoffice/catalogues/show.html.haml
@@ -2,25 +2,29 @@
 - breadcrumb :backoffice_catalogue, @catalogue
 
 .container.p-0.backoffice
-  %h1.mb-3= @catalogue.name
-  = render Presentable::StatusActionsComponent.new(object: @catalogue,
-      publish: policy([:backoffice, @catalogue]).publish?,
-      suspend: policy([:backoffice, @catalogue]).suspend?,
-      unpublish: policy([:backoffice, @catalogue]).unpublish?,
-      destroy: policy([:backoffice, @catalogue]).destroy?)
+  .title-row-wrapper
+    .title-column
+      %h1
+        %span Catalogue:
+        = @catalogue.name
+    = render Presentable::StatusActionsComponent.new(object: @catalogue,
+        publish: policy([:backoffice, @catalogue]).publish?,
+        suspend: policy([:backoffice, @catalogue]).suspend?,
+        unpublish: policy([:backoffice, @catalogue]).unpublish?,
+        destroy: policy([:backoffice, @catalogue]).destroy?)
 
-  .service-box.p-4.mt-3.backoffice-form
+  .service-box.p-4.mt-3.backoffice-form.catalogue
     .logo-wrapper
       %span.helper
       - if @catalogue.logo.attached? && @catalogue.logo.variable?
         = image_tag @catalogue.logo.variant(resize: "100x67"), class: "align-self-center mr-4 float-left img-responsive"
       - else
         = image_tag("catalogue_logo.svg", size: "100x45", class: "align-self-center mr-4 float-left img-responsive")
-    %hr.bottom-hr.mt-5.mb-4
+    %hr.bottom-hr.mt-5.mb-4.d-none
     .btn-group
       - if policy([:backoffice, @catalogue]).edit?
-        = link_to _("Edit"),
+        = link_to _("Edit catalogue"),
                   edit_backoffice_catalogue_path(@catalogue),
-                  class: "btn btn-primary"
+                  class: "btn-special edit-button"
 
-  = link_to _("<- Back to Catalogues"), backoffice_catalogues_path, class: "backoffice-back-link mt-3"
+  = link_to _("<- Back to Catalogues"), backoffice_catalogues_path, class: "backoffice-back-link mt-4 font-weight-bold"

--- a/app/views/backoffice/providers/edit.html.haml
+++ b/app/views/backoffice/providers/edit.html.haml
@@ -2,8 +2,10 @@
 - breadcrumb :backoffice_provider_edit, @provider
 
 .container.p-0.backoffice
-  %h1= _("Edit #{@provider.name} Provider")
-  .container.p-0.backoffice
+  .title-row-wrapper
+    .title-column
+      %h1= _("Edit #{@provider.name} Provider")
+
     = render Presentable::StatusActionsComponent.new(object: @provider,
       publish: policy([:backoffice, @provider]).publish?,
       suspend: policy([:backoffice, @provider]).suspend?,

--- a/app/views/backoffice/providers/show.html.haml
+++ b/app/views/backoffice/providers/show.html.haml
@@ -2,14 +2,18 @@
 - breadcrumb :backoffice_provider, @provider
 
 .container.p-0.backoffice
-  %h1.mb-3= @provider.name
-  = render Presentable::StatusActionsComponent.new(object: @provider,
-    publish: policy([:backoffice, @provider]).publish?,
-    suspend: policy([:backoffice, @provider]).suspend?,
-    unpublish: policy([:backoffice, @provider]).unpublish?,
-    destroy: policy([:backoffice, @provider]).destroy?)
+  .title-row-wrapper
+    .title-column
+      %h1
+        %span Provider:
+        = @provider.name
+    = render Presentable::StatusActionsComponent.new(object: @provider,
+        publish: policy([:backoffice, @provider]).publish?,
+        suspend: policy([:backoffice, @provider]).suspend?,
+        unpublish: policy([:backoffice, @provider]).unpublish?,
+        destroy: policy([:backoffice, @provider]).destroy?)
 
-  .service-box.p-4.mt-3.backoffice-form
+  .service-box.p-4.mt-3.backoffice-form.provider
     .logo-wrapper
       %span.helper
       - if @provider.logo.attached? && @provider.logo.variable?
@@ -22,10 +26,10 @@
       %ul
         - @provider.sources.each do |source|
           %li "#{source.source_type}: #{source.eid}"
-    %hr.bottom-hr.mt-5.mb-4
+    %hr.bottom-hr.d-none
       #actions.btn-group
         - if policy([:backoffice, @provider]).edit?
-          = link_to _("Edit"),
+          = link_to _("Edit provider"),
                 edit_backoffice_provider_path(@provider),
-                class: "btn btn-primary"
-  = link_to _("<- Back to Providers"), backoffice_providers_path, class: "backoffice-back-link mt-3"
+                class: "btn-special edit-button"
+  = link_to _("<- Go back to providers list"), backoffice_providers_path, class: "backoffice-back-link mt-4 font-weight-bold"

--- a/app/views/backoffice/services/_wrapper.html.haml
+++ b/app/views/backoffice/services/_wrapper.html.haml
@@ -2,11 +2,12 @@
   = render "services/errors", service: service
 
 .container.p-0.backoffice
-  = render Presentable::StatusActionsComponent.new(object: service,
-      publish: policy([:backoffice, service]).publish?,
-      suspend: policy([:backoffice, service]).suspend?,
-      unpublish: policy([:backoffice, service]).unpublish?,
-      destroy: policy([:backoffice, service]).destroy?)
+  .title-row-wrapper.mb-0
+    = render Presentable::StatusActionsComponent.new(object: service,
+        publish: policy([:backoffice, service]).publish?,
+        suspend: policy([:backoffice, service]).suspend?,
+        unpublish: policy([:backoffice, service]).unpublish?,
+        destroy: policy([:backoffice, service]).destroy?)
 
 .container.p-0.backoffice
   .pt-3.service-box-redesign.service-detail.backoffice{ "data-shepherd-tour-target": "service-box" }

--- a/app/views/backoffice/services/edit.html.haml
+++ b/app/views/backoffice/services/edit.html.haml
@@ -2,8 +2,10 @@
 - breadcrumb :backoffice_service_edit, @service
 
 .container.p-0.backoffice
-  %h1= _("Edit #{@service.name} Service")
-  .container.p-0.backoffice
+  .title-row-wrapper
+    .title-column
+      %h1= _("Edit #{@service.name} Service")
+
     = render Presentable::StatusActionsComponent.new(object: @service,
       publish: policy([:backoffice, @service]).publish?,
       suspend: policy([:backoffice, @service]).suspend?,

--- a/spec/features/backoffice/services_spec.rb
+++ b/spec/features/backoffice/services_spec.rb
@@ -307,7 +307,7 @@ RSpec.feature "Services in backoffice", manager_frontend: true do
       visit backoffice_service_path(service)
       expect { click_on "Publish" }.to have_enqueued_job(Ess::UpdateJob)
 
-      expect(page).to have_content("Status: published")
+      expect(page).to have_content("published")
     end
 
     scenario "I can unpublish service" do
@@ -316,7 +316,7 @@ RSpec.feature "Services in backoffice", manager_frontend: true do
       visit backoffice_service_path(service)
       expect { click_on "Unpublish" }.to have_enqueued_job(Ess::UpdateJob)
 
-      expect(page).to have_content("Status: unpublished")
+      expect(page).to have_content("unpublished")
     end
 
     scenario "I can edit any service" do

--- a/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
+++ b/test/system/cypress/e2e/regression_tests/backoffice/resources/owned_resources.spec.ts
@@ -41,10 +41,10 @@ describe("Owned services", () => {
     cy.contains("div.alert-success", message.successCreationMessage).should("be.visible");
     cy.contains("a", "Edit service").should("be.visible");
     cy.contains("a", "Set parameters and offers").should("be.visible");
-    cy.contains("span", "unpublished").should("be.visible");
+    cy.contains("div", "unpublished").should("be.visible");
     cy.get("[data-e2e='publish-btn']").click();
     cy.get("[data-e2e='confirm-accept']").click();
-    cy.contains("span", "published").should("be.visible");
+    cy.contains("div", "published").should("be.visible");
     cy.get(".service-details-header h2")
       .invoke("text")
       .then((value) => {


### PR DESCRIPTION
closes #124 

refreshed views and status/actions button over whole backoffice:

![image](https://github.com/user-attachments/assets/12a3f404-4ee0-4d51-9024-802c9adc0920)

![image](https://github.com/user-attachments/assets/5666ab94-6e63-4c4c-bd64-20cc1766bad4)

![image](https://github.com/user-attachments/assets/055f9217-86d4-4587-8bd7-0c5573ed8147)

