### PR TITLE
fix:[#165] Disable custom assets config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Please view this file on the master branch, on stable branches it's out of date.
 
 - New provider wizard form (@maria-j-k, @goreck888, @jarekzet)
 
+### Deprecated
+
+- `ASSET_HOST` and `ASSET_PROTOCOL` environment variables (@goreck888)
+
 ## [3.58.2]
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -261,8 +261,6 @@ We are currently using the following ENV variables:
   links to EOSC portal
 * `PROVIDERS_DASHBOARD_URL` - Provider's Dashboard URL used to create links to the provider's dashboard
 * `USER_DASHBOARD_URL` User Dashboard URL for links in the landing page. Default is `https://my.eosc-portal.eu/`
-* `ASSET_HOST` and `ASSET_PROTOCOL` - assets mailer config is mandatory
-  (e.g. ASSET_HOST = marketplace.eosc-portal.eu/ and ASSET_PROTOCOL = https )
 * `RATE_AFTER_PERIOD` - number of days after which user can rate resource (default is set to 90 days)
 * `ATTRIBUTES_DOCS_URL` - offer attributes definition documentation (external link)
 * `AUTOLOGIN_DOMAIN` - parent domain in which the autologin scheme should work (see [autologin](#autologin-across-eosc-portaleu-domains))

--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,4 +1,4 @@
-@import "trix.css";
+@import "trix/dist/trix";
 
 // We need to override trix.css’s image gallery styles to accommodate the
 // <action-text-attachment> element we wrap around attachments. Otherwise,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,10 +126,6 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV.fetch("ROOT_URL", nil) }
   config.action_mailer.delivery_method = :smtp
 
-  host = "#{ENV.fetch("ASSET_HOST", "localhost")}"
-  config.action_controller.asset_host = host
-  config.action_mailer.asset_host = "#{ENV.fetch("ASSET_PROTOCOL", "http")}://#{host}"
-
   # SMTP settings
   config.action_mailer.smtp_settings = {
       address: ENV.fetch("SMPT_ADDRESS", nil),


### PR DESCRIPTION
Remove customizing asset host
for docker conterization purposes

Closes #165