### PR TITLE
feat: [#162] Implement integration with BOS API

### DIFF
--- a/app/controllers/projects/services/conversations_controller.rb
+++ b/app/controllers/projects/services/conversations_controller.rb
@@ -20,6 +20,7 @@ class Projects::Services::ConversationsController < ApplicationController
       )
 
     if Message::Create.new(@message).call
+      Bos::PostMessageJob.perform_later(@message)
       flash[:notice] = _("Message sent successfully")
       redirect_to project_service_conversation_path(@project, @project_item)
     else

--- a/app/jobs/bos/create_order_job.rb
+++ b/app/jobs/bos/create_order_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Bos::CreateOrderJob < ApplicationJob
+  include BosRetryable
+
+  def perform(project_item)
+    Bos::Client.new.create_order(project_item)
+  end
+end

--- a/app/jobs/bos/post_message_job.rb
+++ b/app/jobs/bos/post_message_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Bos::PostMessageJob < ApplicationJob
+  include BosRetryable
+
+  def perform(message)
+    Bos::Client.new.create_message(message) if message.question? && message.project_item.present?
+  end
+end

--- a/app/jobs/concerns/bos_retryable.rb
+++ b/app/jobs/concerns/bos_retryable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BosRetryable
+  extend ActiveSupport::Concern
+
+  included do
+    queue_as :orders
+
+    retry_on Faraday::TimeoutError, Faraday::ConnectionFailed, wait: ->(executions) { 3**executions }, attempts: 5
+  end
+end

--- a/app/services/bos/client.rb
+++ b/app/services/bos/client.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+
+class Bos::Client
+  def initialize
+    @bos_enabled = Rails.configuration.bos_enabled
+
+    @conn =
+      Faraday.new(url: Rails.configuration.bos_base_url) do |f|
+        f.request :json
+        f.response :raise_error
+        f.response :json, content_type: /\bjson$/
+        f.headers["x-key"] = Rails.configuration.bos_api_key
+        f.headers["Content-Type"] = "application/json"
+        f.headers["Accept"] = "application/json"
+      end
+  end
+
+  def create_order(project_item)
+    post(
+      "/api/orders",
+      {
+        external_ref: project_item.iid.to_s,
+        project_ref: project_item.project_id.to_s,
+        config: {
+          params: serialize_order_params(project_item)
+        },
+        platforms: project_item.offer.service.platforms.map(&:name),
+        resource_ref: project_item.offer.service.friendly_id,
+        resource_type: project_item.offer.order_type,
+        resource_name: project_item.offer.service.name,
+        provider_pids:
+          project_item.offer.service.providers.map(&:pid).presence ||
+            [project_item.offer.service.resource_organisation.pid]
+      }
+    )
+  end
+
+  def create_message(message)
+    post(
+      "/api/messages",
+      {
+        content: message.message,
+        scope: "public",
+        user_email: message.author.email,
+        order_external_ref: message.project_item.iid.to_s
+      }
+    )
+  end
+
+  def create_user(user)
+    user_type = ["mp_user"]
+    user_type.push("provider_manager") if user.data_administrator?
+
+    post("/api/users", { name: user.full_name, email: user.email, user_type: user_type })
+  end
+
+  def create_provider(provider)
+    post(
+      "/api/providers",
+      {
+        name: provider.name,
+        website: provider.website,
+        pid: provider.pid,
+        manager_emails: provider.data_administrators.map(&:email)
+      }
+    )
+  end
+
+  private
+
+  def post(path, body)
+    unless @bos_enabled
+      Rails.logger.warn("Nothing to do, BOS integration is DISABLED by an ENV variable")
+      return
+    end
+
+    response = @conn.post(path) { |req| req.body = body.to_json }
+    response.body
+  rescue Faraday::Error => e
+    Rails.logger.error("[BOS] Error calling #{path}: #{e.message}, body: #{e.response_body}")
+    raise
+  end
+
+  def serialize_order_params(project_item)
+    project_item.properties.map { |property| { value: property["value"], label: property["label"] } }
+  end
+end

--- a/app/services/project_item/create.rb
+++ b/app/services/project_item/create.rb
@@ -62,6 +62,8 @@ class ProjectItem::Create < ApplicationService
           ProjectItem::ReadyJob.perform_later(project_item, @message)
           ProjectItemMailer.added_to_project(project_item).deliver_later
         end
+
+        Bos::CreateOrderJob.perform_later(project_item)
       end
 
       updated_project = Project.find_by(id: @project.id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -99,5 +99,9 @@ module Mp
     config.enable_external_search = ActiveModel::Type::Boolean.new.cast(ENV.fetch("MP_ENABLE_EXTERNAL_SEARCH", false))
     config.analytics_enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch("ANALYTICS_ENABLED", false))
     config.whitelabel = ENV.fetch("MP_WHITELABEL", true)
+
+    config.bos_base_url = ENV.fetch("BOS_API_URL", "http://localhost:8000")
+    config.bos_api_key = ENV.fetch("BOS_API_KEY", "")
+    config.bos_enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch("BOS_ENABLED", false))
   end
 end

--- a/lib/tasks/bos.rake
+++ b/lib/tasks/bos.rake
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+namespace :bos do
+  desc "Sync all users with BOS"
+  task sync_users: :environment do
+    client = Bos::Client.new
+
+    User.find_each do |user|
+      puts "Syncing user: #{user.email}"
+      client.create_user(user)
+      puts "Synced #{user.email}"
+    rescue StandardError => e
+      puts "Failed to sync user #{user.email}: #{e.message}"
+    end
+  end
+
+  desc "Sync all providers with BOS"
+  task sync_providers: :environment do
+    client = Bos::Client.new
+
+    Provider.find_each do |provider|
+      puts "Syncing provider: #{provider.name}"
+      client.create_provider(provider)
+      puts "Synced #{provider.name}"
+    rescue StandardError => e
+      puts "Failed to sync provider #{provider.name}: #{e.message}"
+    end
+  end
+end


### PR DESCRIPTION
Closes #162

Added a client for BOS interaction, supporting creation of orders and messages (also users and providers for future use). Added sync of orders and messages with retries through a separate ActiveMQ jobs.

Left todo is to:
- think how we'll get providers and users into BOS (should be done through keycloak ideally)

There are 3 new env vars:
- BOS_API_KEY
- BOS_API_URL
- BOS_ENABLED (boolean), defaults to false