### PR TITLE
fix: Fix creating offers

### DIFF
--- a/app/controllers/backoffice/services/offers/summaries_controller.rb
+++ b/app/controllers/backoffice/services/offers/summaries_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Backoffice::Services::Offers::SummariesController < Backoffice::Services::OffersController
+  before_action :find_service
+  before_action :find_offer_and_authorize, only: %i[update]
+
+  def create
+    submit_summary
+  end
+
+  def update
+    submit_summary
+  end
+
+  def submit_summary
+    template = offer_template
+    authorize(template)
+    render partial: "backoffice/services/offers/steps/summary", locals: { offer: template }
+  end
+
+  private
+
+  def find_offer_and_authorize
+    @offer = @service.offers.find_by(iid: params[:offer_id])
+    authorize(@offer)
+  end
+end

--- a/app/controllers/backoffice/services/offers_controller.rb
+++ b/app/controllers/backoffice/services/offers_controller.rb
@@ -40,12 +40,6 @@ class Backoffice::Services::OffersController < Backoffice::ApplicationController
     end
   end
 
-  def submit_summary
-    template = offer_template
-    authorize(template)
-    render partial: "backoffice/services/offers/steps/summary", locals: { offer: template }
-  end
-
   def edit
   end
 

--- a/app/controllers/services/ordering_configuration/offers/summaries_controller.rb
+++ b/app/controllers/services/ordering_configuration/offers/summaries_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Services::OrderingConfiguration::Offers::SummariesController < Backoffice::Services::OffersController
+  before_action :find_service
+  before_action :find_offer_and_authorize, only: %i[update]
+
+  def create
+    submit_summary
+  end
+
+  def update
+    submit_summary
+  end
+
+  def submit_summary
+    template = offer_template
+    authorize(template)
+    render partial: "backoffice/services/offers/steps/summary", locals: { offer: template }
+  end
+end

--- a/app/javascript/controllers/offer_controller.js
+++ b/app/javascript/controllers/offer_controller.js
@@ -170,10 +170,10 @@ export default class extends Controller {
     const formData = new FormData(this.formTarget);
     const serviceId = this.formTarget.dataset.serviceId;
     const offerId = this.formTarget.dataset.offerId;
-    const url = `/backoffice/services/${serviceId}/offers/${offerId}/submit`;
+    const url = `/backoffice/services/${serviceId}/offers/${offerId}/summary`;
 
     fetch(url, {
-      method: "POST",
+      method: offerId === "new" ? "POST" : "PATCH",
       body: formData,
       headers: {
         "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content,

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -57,8 +57,6 @@ class Offer < ApplicationRecord
   before_validation :set_internal
   before_validation :set_oms_details
   before_validation :sanitize_oms_params
-  before_validation :set_iid
-  after_initialize :set_iid
 
   has_many :bundle_offers
   has_many :bundles, through: :bundle_offers, dependent: :destroy
@@ -70,6 +68,7 @@ class Offer < ApplicationRecord
   belongs_to :offer_type, class_name: "Vocabulary::ServiceCategory", optional: true
   belongs_to :offer_subtype, class_name: "Vocabulary::ServiceCategory", optional: true
 
+  validate :set_iid, on: :create
   validates :service, presence: true
   validates :iid, presence: true, numericality: true
   validates :order_url, mp_url: true, if: :order_url?
@@ -88,6 +87,13 @@ class Offer < ApplicationRecord
     validate :check_oms_params, if: -> { current_oms.present? }
     validate :same_order_type_as_in_service, if: -> { service&.order_type.present? }
   end
+
+  validate :check_main_bundles, if: -> { draft? }
+  validates :service, presence: true
+  validates :iid, presence: true, numericality: true
+  validates :order_url, mp_url: true, if: :order_url?
+
+  validate :primary_oms_exists?, if: -> { primary_oms_id.present? }
 
   before_destroy :check_main_bundles
 

--- a/app/views/backoffice/services/offers/_form.html.haml
+++ b/app/views/backoffice/services/offers/_form.html.haml
@@ -3,7 +3,7 @@
   Offers%3A-Adding-and-Editing?type=design&node-id=2-73&mode=design&t=F215vnzstlg4yUqR-0
 
 = simple_form_for offer_form_source_module, html: { data: {controller: "offer exit", "offer-target": "form",
-  "service-id": service.id, "offer-id": offer&.id || "new" }} do |f|
+  "service-id": service.id, "offer-id": offer&.iid || "new" }} do |f|
   = f.hidden_field :from, value: local_assigns[:from]
 
   .steps-row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  pid_format_constraint = %r{[^/]+(?:/[^/]+)?}
+
   ############################## IMPORTANT!!! ################################
   # !!! Code of high security risk impact !!!
   # AAI service authentication is skipped for tests purpose
@@ -23,7 +25,7 @@ Rails.application.routes.draw do
   get "/datasources/:id", to: redirect("/services/%{id}")
   get "backoffice/datasources/:id", to: redirect("backoffice/services/%{id}")
 
-  resources :services, only: %i[index show], constraints: { id: %r{[^/]+} } do
+  resources :services, only: %i[index show], constraints: { id: pid_format_constraint } do
     scope module: :services do
       resources :offers, only: %i[index] do
         scope module: :offers do
@@ -46,6 +48,7 @@ Rails.application.routes.draw do
           resources :offers, only: %i[index new edit create update destroy] do
             resource :publish, controller: "offers/publishes", only: :create
             resource :draft, controller: "offers/drafts", only: :create
+            resource :summary, controller: "offers/summaries", only: %i[create update]
           end
           resources :bundles, only: %i[index new edit create update destroy] do
             resource :publish, controller: "bundles/publishes", only: :create
@@ -92,7 +95,7 @@ Rails.application.routes.draw do
 
   resource :profile, only: %i[show edit update destroy]
 
-  resources :providers, only: %i[index show], constraints: { id: %r{[^/]+} } do
+  resources :providers, only: %i[index show], constraints: { id: pid_format_constraint } do
     scope module: :providers do
       resource :question, only: %i[new create]
       resources :details, only: :index
@@ -119,6 +122,7 @@ Rails.application.routes.draw do
         resources :offers do
           resource :publish, controller: "offers/publishes", only: :create
           resource :draft, controller: "offers/drafts", only: :create
+          resource :summary, controller: "offers/summaries", only: %i[create update]
         end
         resources :bundles do
           resource :publish, controller: "bundles/publishes", only: :create
@@ -156,13 +160,16 @@ Rails.application.routes.draw do
     end
   end
 
-  post "/backoffice/services/:service_id/offers/:offer_id/duplicate", to: "backoffice/services/offers#duplicate", 
-    as: :duplicate_offer
-
   post "/backoffice/services/:service_id/offers/fetch_subtypes", to: "backoffice/services/offers#fetch_subtypes"
 
-  post "/backoffice/services/:service_id/offers/:offer_id/submit", to: "backoffice/services/offers#submit_summary"
-  patch "/backoffice/services/:service_id/offers/:offer_id/submit", to: "backoffice/services/offers#submit_summary"
+  post "/backoffice/services/:service_id/offers/:offer_id/duplicate", to: "backoffice/services/offers#duplicate",
+as: :duplicate_offer
+  
+
+  resource :executive, only: :show
+  namespace :executive do
+    resources :statistics, only: :index
+  end
 
   mount Rswag::Ui::Engine => "/api_docs/swagger"
   mount Rswag::Api::Engine => "/api_docs/swagger"
@@ -174,7 +181,7 @@ Rails.application.routes.draw do
     end
 
     namespace :v1 do
-      resources :resources, only: %i[index show], constraints: { id: %r{[^/]+} } do
+      resources :resources, only: %i[index show], constraints: { id: pid_format_constraint } do
         resources :offers, only: %i[index create show destroy update], module: :resources
       end
       resources :oms, controller: :omses, only: %i[index show update] do
@@ -185,8 +192,8 @@ Rails.application.routes.draw do
         end
       end
       namespace :ess do
-        resources :services, only: %i[index show], constraints: { id: %r{[^/]+} }
-        resources :datasources, only: %i[index show], constraints: { id: %r{[^/]+} }
+        resources :services, only: %i[index show], constraints: { id: pid_format_constraint }
+        resources :datasources, only: %i[index show], constraints: { id: pid_format_constraint }
         resources :providers, only: %i[index show]
         resources :catalogues, only: %i[index show]
         resources :offers, only: %i[index show]
@@ -221,7 +228,7 @@ Rails.application.routes.draw do
   resource :tour_feedbacks, only: :create
 
   direct :overview_tour_first_service do |params|
-    service = Service.where(status: %i[published errored]).order(:name).first
+    service = Service.where(status: %i[published unverified errored]).order(:name).first
     service_path(service, params)
   end
 


### PR DESCRIPTION
Fix creating offers by including missing
`Backoffice::OffersHelper` to the
`Backoffice::Services::OffersController`
Move `submit_summary` method in the
mentioned `OffersController` to the separate
`Backoffice::Services::Offers::SummariesController` with create/update methods
Fix `set_iid` method hook from
before_validation to create
Fix form offerId data from id to iid