### PR TITLE
fix: Extend ActionMailer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ We are currently using the following ENV variables:
 * `SMTP_ADDRESS` - smtp mail server address
 * `SMTP_USERNAME` - smtp user name or email address
 * `SMTP_PASSWORD` - smtp password
+* `SMTP_PORT` - custom SMTP port
+* `SMTP_AUTHENTICATION` - custom authentication method
+* `SMTP_STARTTLS` - enable or disable starttls
 * `FROM_EMAIL` - from email (if not set `from@example.com` will be used)
 * `GOOGLE_ANALYTICS` - google analytics key for GMT (if present than analytics
   script is added into head section)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,11 +129,11 @@ Rails.application.configure do
   # SMTP settings
   config.action_mailer.smtp_settings = {
       address: ENV.fetch("SMPT_ADDRESS", nil),
-      port: 587,
+      port: ENV.fetch("SMTP_PORT", 587),
       user_name: ENV.fetch("SMPT_USERNAME", nil),
       password: ENV.fetch("SMPT_PASSWORD", nil),
-      authentication: "plain",
-      enable_starttls_auto: true
+      authentication: ENV.fetch("SMTP_AUTHENTICATION", "plain"),
+      enable_starttls_auto: ENV.fetch("SMTP_STARTTLS", true)
   }
 
   # custom error pages with webpage layout


### PR DESCRIPTION
Add new variables for required
custom config:
- `SMTP_PORT` - default 587
- `SMTP_AUTHENTICATION` - default "plain"
- `SMTP_STARTTLS` - default `true`