### PR TITLE
Fix Docker images not building if SECRET_KEY_BASE is `nil`

### DIFF
--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -4,8 +4,7 @@ Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
     authenticated_encrypted_cookie_salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
     signed_cookie_salt = Rails.application.config.action_dispatch.signed_cookie_salt
-
-    secret_key_base = ENV.fetch("SECRET_KEY_BASE", Rails.application.credentials.secret_key_base)
+    secret_key_base = Rails.application.secret_key_base
 
     key_generator = ActiveSupport::KeyGenerator.new(
       secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,7 +9,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'a6d3c687f41d5ba8b5f84d17b444ef4af8b4cc1bc2463cac9b1dcd4296f8c3dd86352bee5477c6c6eaf99855726432486d267139cbfc10207409994238f54ca4'
-  config.secret_key = ENV.fetch("SECRET_KEY_BASE", Rails.application.credentials.secret_key_base)
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/lib/tasks/cookies_migrator.rake
+++ b/lib/tasks/cookies_migrator.rake
@@ -15,7 +15,7 @@ namespace :encrypt_cookies do
   def encrypt_cookies_with(algorithm = OpenSSL::Digest::SHA256)
     Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
       salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
+      secret_key_base = Rails.application.secret_key_base
 
       key_generator = ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000, hash_digest_class: algorithm)
       key_len = ActiveSupport::MessageEncryptor.key_len


### PR DESCRIPTION
In `config/initializers/cookie_rotator.rb` and `config/initializers/devise.rb`, `secret_key_base` is obtained using `ENV.fetch("SECRET_KEY_BASE", Rails.application.credentials.secret_key_base)`. This has two issues:

1. `Rails.application.credentials.secret_key_base` should be `Rails.application.secret_key_base`
2. Fetching `SECRET_KEY_BASE` directly prevents `SECRET_KEY_BASE_DUMMY` from working

The Dockerfile correctly uses `SECRET_KEY_BASE_DUMMY`, but builds fail if `SECRET_KEY_BASE` is not set.

This PR also corrects the use of `Rails.application.secrets.secret_key_base` in `lib/tasks/cookies_migrator.rake`.