### PR TITLE
ci: add Docker build workflow for automated releases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-push:
+    runs-on: self-hosted
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            fiddev/whitelabel-marketplace:${{ steps.version.outputs.version }}
+            fiddev/whitelabel-marketplace:latest
+      
+      - name: Cleanup
+        if: always()
+        run: |
+          docker system prune -af --volumes
+          docker builder prune -af


### PR DESCRIPTION
- Build and push to Docker Hub on version tags
- Tag images with version number (without 'v' prefix) and latest
- Run on self-hosted runner
- Triggered only on tags matching v*.*.*"