### PR TITLE
fix: [AdHoc] Add owner_email to BOS orders call

### DIFF
--- a/app/services/bos/client.rb
+++ b/app/services/bos/client.rb
@@ -39,6 +39,7 @@ class Bos::Client
         resource_ref: project_item.offer.service.friendly_id,
         resource_type: project_item.offer.order_type,
         resource_name: project_item.offer.service.name,
+        owner_email: project_item.user.email,
         provider_pids:
           project_item.offer.service.providers.map(&:pid).presence ||
             [project_item.offer.service.resource_organisation.pid]


### PR DESCRIPTION
To be merged together with https://github.com/cyfronet-fid/backoffice-ordering-system/pull/45