### PR TITLE
feat: build and publish docker image to GHCR

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -7,6 +7,11 @@ name: automatic-release
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      version: ${{ steps.release.outputs.version }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
@@ -28,3 +33,16 @@ jobs:
           git merge --no-ff origin/master -m "chore: auto-merge master to development"
           git push
         if: ${{ steps.release.outputs.release_created }}
+
+  docker-release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      push: true
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.version }}
+        ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+name: Docker build
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: "Newline-separated list of image tags to apply"
+        required: true
+        type: string
+      labels:
+        description: "Newline-separated list of OCI labels to apply"
+        required: false
+        type: string
+        default: ""
+      push:
+        description: "Push the built image to the registry"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        if: inputs.push
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ inputs.push }}
+          tags: ${{ inputs.tags }}
+          labels: ${{ inputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Docker image
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
+  pull_request:
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+    steps:
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+  build:
+    needs: meta
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      tags: ${{ needs.meta.outputs.tags }}
+      labels: ${{ needs.meta.outputs.labels }}
+      push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary
- Adds `docker-image.yml`: builds the app image on push to `master` (tags `:latest`), on manually pushed tags matching `v*.*.*` (tags with version), and on PRs (build-only validation, no push).
- Adds `docker-build.yml`: shared reusable workflow that actually builds/pushes to `ghcr.io/cyfronet-fid/whitelabel-marketplace`, used by both of the above.
- Extends `automatic-release.yml` with a `docker-release` job that builds/publishes the versioned image right after release-please cuts a release, since tags created via `GITHUB_TOKEN` don't otherwise trigger other workflows.

## Test plan
- [x] `docker build .` succeeds locally with the existing `Dockerfile`
- [x] YAML validated (`ruby -ryaml`)
- [ ] Verify first run on this PR builds the image (no push, since it's a PR)
- [ ] Verify `:latest` gets published after merging to `master`
- [ ] Verify versioned tag gets published after the next release-please release