### PR TITLE
fix: correct latest-tag condition for docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=pr
 
   build:
     needs: meta


### PR DESCRIPTION
## Summary
Follow-up to #257. The first real run on `master` after merging failed: https://github.com/cyfronet-fid/whitelabel-marketplace/actions/runs/28669738024

Root cause: this repo's actual GitHub default branch is `development`, not `master` (verified via `gh api repos/cyfronet-fid/whitelabel-marketplace --jq .default_branch`). So `{{is_default_branch}}` in `docker/metadata-action` was always `false` on push to `master`, which meant metadata-action produced zero tags, and `docker/build-push-action` then failed trying to push an image with `push: true` and no tags.

- Replaced `enable={{is_default_branch}}` with an explicit `enable=${{ github.ref == 'refs/heads/master' }}` check.
- Added `type=ref,event=pr` so pull_request runs (build-only) get a real tag (`pr-<number>`) instead of metadata-action returning an empty tag list with a warning.

## Test plan
- [x] YAML validated
- [ ] Confirm `Docker image` workflow succeeds and publishes `:latest` on the next push to `master`
- [ ] Confirm PR runs build with a `pr-<number>` tag, no push